### PR TITLE
Add .gitattributes files for module README files

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,7 +39,7 @@ param (
     [string] $BuildModulePath,
 
     [Parameter()]
-    [version] $BuildModuleVersion = "0.2.2"
+    [version] $BuildModuleVersion = "0.2.3"
 )
 
 $ErrorActionPreference = $ErrorActionPreference ? $ErrorActionPreference : 'Stop'

--- a/modules/.gitattributes
+++ b/modules/.gitattributes
@@ -1,0 +1,1 @@
+README.md   text eol=lf


### PR DESCRIPTION
Running the `brm generate` tool resets the line-endings on the generated README files which causes unnecessary 'git diff' noise.

Also updates to the latest build module, with the updated behaviour re: installing Bicep tooling