### PR TITLE
Add modules for handling App Configuration key-values backed by Key Vault secrets

### DIFF
--- a/modules/general/app-config-key-vault-secret/README.md
+++ b/modules/general/app-config-key-vault-secret/README.md
@@ -1,0 +1,58 @@
+# App Configuration Key Vault Secret
+
+Adds or updates an App Configuration key-value backed by an Azure Key Vault secret.
+
+## Description
+
+Adds or updates an App Configuration key-value with a reference to an Azure Key Vault secret and sets the relevant content-type (`application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8`).
+
+Some libraries and tools can understand the linked secret reference and retrieve the underlying secret value for the given App Configuration key (e.g. see [ASP.NET Core example](https://learn.microsoft.com/en-us/azure/azure-app-configuration/use-key-vault-references-dotnet-core)).
+
+This module allows for either using existing Key Vault secrets and for automatically creating new secrets with a given value.
+
+## Parameters
+
+| Name                 | Type           | Required | Description                                                                                                                  |
+| :------------------- | :------------: | :------: | :--------------------------------------------------------------------------------------------------------------------------- |
+| `appConfigKey`       | `string`       | No       | Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name.          |
+| `secretName`         | `string`       | Yes      | The name of the secret in Key Vault (either existing or to be created).                                                      |
+| `secretValue`        | `secureString` | No       | Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault. |
+| `appConfigStoreName` | `string`       | Yes      | The name of the App Configuration Store.                                                                                     |
+| `keyVaultName`       | `string`       | Yes      | The name of the Key Vault instance.                                                                                          |
+| `label`              | `string`       | No       | Optional label attribute to apply to the App Configuration key-value.                                                        |
+
+## Outputs
+
+| Name                 | Type   | Description                                                                          |
+| :------------------- | :----: | :----------------------------------------------------------------------------------- |
+| secretUriWithVersion | string | The secret URI (with version) of the secret backing the App Configuration key-value. |
+| appConfigKey         | string | The key for the App Configuration key-value.                                         |
+
+## Examples
+
+### Create key-value with new secret
+
+```bicep
+module ackvs 'br:<registry-fqdn>/bicep/general/app-config-key-vault-secret:<version>' = {
+  name: 'ackvs'
+  params: {
+    appConfigStoreName: 'myappconfigstore'
+    keyVaultName: 'mykeyvault'
+    secretName: 'mysecret'
+    secretValue: 's3cr3t!'
+  }
+}
+```
+
+### Create key-value using an existing secret
+
+```bicep
+module ackvs 'br:<registry-fqdn>/bicep/general/app-config-key-vault-secret:<version>' = {
+  name: 'ackvs'
+  params: {
+    appConfigStoreName: 'myappconfigstore'
+    keyVaultName: 'mykeyvault'
+    secretName: 'mysecret' // This secret must already exist in the 'mykeyvault' Key Vault
+  }
+}
+```

--- a/modules/general/app-config-key-vault-secret/README.md
+++ b/modules/general/app-config-key-vault-secret/README.md
@@ -8,7 +8,7 @@ Adds or updates an App Configuration key-value with a reference to an Azure Key 
 
 Some libraries and tools can understand the linked secret reference and retrieve the underlying secret value for the given App Configuration key (e.g. see [ASP.NET Core example](https://learn.microsoft.com/en-us/azure/azure-app-configuration/use-key-vault-references-dotnet-core)).
 
-This module allows for either using existing Key Vault secrets and for automatically creating new secrets with a given value.
+This module allows for either using existing Key Vault secrets or for automatically creating new secrets with a given value.
 
 ## Parameters
 

--- a/modules/general/app-config-key-vault-secret/main.bicep
+++ b/modules/general/app-config-key-vault-secret/main.bicep
@@ -1,0 +1,53 @@
+@description('Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name.')
+param appConfigKey string = ''
+
+@description('The name of the secret in Key Vault (either existing or to be created).')
+param secretName string
+
+@secure()
+@description('Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault.')
+param secretValue string = ''
+
+@description('The name of the App Configuration Store.')
+param appConfigStoreName string
+
+@description('The name of the Key Vault instance.')
+param keyVaultName string
+
+@description('Optional label attribute to apply to the App Configuration key-value.')
+param label string = ''
+
+resource app_config_store 'Microsoft.AppConfiguration/configurationStores@2020-06-01' existing = {
+  name: appConfigStoreName
+}
+
+var secretNameSanitized = !empty(secretValue) ? replace(secretName, ':', '--') : secretName
+module secret '../key-vault-secret/main.bicep' = {
+  name: secretNameSanitized
+  params: {
+    secretName: secretNameSanitized
+    keyVaultName: keyVaultName
+    useExisting: empty(secretValue)
+    contentValue: empty(secretValue) ? '' : secretValue
+  }
+}
+
+var keyVaultSecretRef = {
+    uri: secret.outputs.secretUriWithVersion
+}
+
+var sanitisedAppConfigKey = '${replace(replace(uriComponent(empty(appConfigKey) ? secretName : appConfigKey), '~', '~7E'), '%', '~')}${empty(label) ? '' : '$${label}'}'
+
+resource key_value 'Microsoft.AppConfiguration/configurationStores/keyValues@2021-03-01-preview' = {
+  name: sanitisedAppConfigKey
+  parent: app_config_store
+  properties: {
+      contentType: 'application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8'
+      value: string(keyVaultSecretRef)
+    }
+}
+
+@description('The secret URI (with version) of the secret backing the App Configuration key-value.')
+output secretUriWithVersion string = secret.outputs.secretUriWithVersion
+@description('The key for the App Configuration key-value.')
+output appConfigKey string = sanitisedAppConfigKey

--- a/modules/general/app-config-key-vault-secret/main.json
+++ b/modules/general/app-config-key-vault-secret/main.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "4881392564295863085"
+    }
+  },
+  "parameters": {
+    "appConfigKey": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name."
+      }
+    },
+    "secretName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the secret in Key Vault (either existing or to be created)."
+      }
+    },
+    "secretValue": {
+      "type": "secureString",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault."
+      }
+    },
+    "appConfigStoreName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Configuration Store."
+      }
+    },
+    "keyVaultName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Key Vault instance."
+      }
+    },
+    "label": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional label attribute to apply to the App Configuration key-value."
+      }
+    }
+  },
+  "variables": {
+    "secretNameSanitized": "[if(not(empty(parameters('secretValue'))), replace(parameters('secretName'), ':', '--'), parameters('secretName'))]",
+    "sanitisedAppConfigKey": "[format('{0}{1}', replace(replace(uriComponent(if(empty(parameters('appConfigKey')), parameters('secretName'), parameters('appConfigKey'))), '~', '~7E'), '%', '~'), if(empty(parameters('label')), '', format('${0}', parameters('label'))))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+      "apiVersion": "2021-03-01-preview",
+      "name": "[format('{0}/{1}', parameters('appConfigStoreName'), variables('sanitisedAppConfigKey'))]",
+      "properties": {
+        "contentType": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+        "value": "[string(createObject('uri', reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[variables('secretNameSanitized')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secretName": {
+            "value": "[variables('secretNameSanitized')]"
+          },
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "useExisting": {
+            "value": "[empty(parameters('secretValue'))]"
+          },
+          "contentValue": {
+            "value": "[if(empty(parameters('secretValue')), '', parameters('secretValue'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "12015994460177070841"
+            }
+          },
+          "parameters": {
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Enter the secret name."
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "defaultValue": "text/plain",
+              "metadata": {
+                "description": "Type of the secret"
+              }
+            },
+            "contentValue": {
+              "type": "secureString",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Value of the secret"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the vault"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, a pre-existing secret will be returned"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2021-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "value": "[parameters('contentValue')]"
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+              "metadata": {
+                "description": "The key vault URI linking to the new/updated secret"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "secretUriWithVersion": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value]",
+      "metadata": {
+        "description": "The secret URI (with version) of the secret backing the App Configuration key-value."
+      }
+    },
+    "appConfigKey": {
+      "type": "string",
+      "value": "[variables('sanitisedAppConfigKey')]",
+      "metadata": {
+        "description": "The key for the App Configuration key-value."
+      }
+    }
+  }
+}

--- a/modules/general/app-config-key-vault-secret/metadata.json
+++ b/modules/general/app-config-key-vault-secret/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "App Configuration Key Vault Secret",
+  "summary": "Adds or updates an App Configuration key-value backed by an Azure Key Vault secret.",
+  "owner": "endjin"
+}

--- a/modules/general/app-config-key-vault-secret/test/main.test.bicep
+++ b/modules/general/app-config-key-vault-secret/test/main.test.bicep
@@ -1,8 +1,8 @@
-param prefix string = uniqueString(resourceGroup().id)
+param suffix string = uniqueString(resourceGroup().id)
 param location string = resourceGroup().location
 
 resource kv 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
-  name: '${prefix}kv'
+  name: 'kv${suffix}'
   location: location
   properties: {
     sku: {
@@ -15,7 +15,7 @@ resource kv 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
 }
 
 resource acs 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
-  name: '${prefix}acs'
+  name: 'acs${suffix}'
   location: location
   sku: {
     name: 'Standard'

--- a/modules/general/app-config-key-vault-secret/test/main.test.bicep
+++ b/modules/general/app-config-key-vault-secret/test/main.test.bicep
@@ -1,0 +1,50 @@
+param prefix string = uniqueString(resourceGroup().id)
+param location string = resourceGroup().location
+
+resource kv 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
+  name: '${prefix}kv'
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenant().tenantId
+    accessPolicies: []
+  }
+}
+
+resource acs 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
+  name: '${prefix}acs'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+}
+
+module ackvs '../main.bicep' = {
+  name: 'ackvs'
+  params: {
+    appConfigStoreName: acs.name
+    keyVaultName: kv.name
+    secretName: 'mysecret1'
+    secretValue: 's3cr3t!'
+  }
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
+  parent: kv
+  name: 'mysecret2'
+  properties: {
+    value: 'p@55w0rd!'
+  }
+}
+
+module ackvs_existing_secret '../main.bicep' = {
+  name: 'ackvs_existing_secret'
+  params: {
+    appConfigStoreName: acs.name
+    keyVaultName: kv.name
+    secretName: 'mysecret2'
+  }
+}

--- a/modules/general/app-config-key-vault-secret/test/main.test.json
+++ b/modules/general/app-config-key-vault-secret/test/main.test.json
@@ -1,0 +1,468 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "2528679654793620450"
+    }
+  },
+  "parameters": {
+    "prefix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}kv', parameters('prefix'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "tenantId": "[tenant().tenantId]",
+        "accessPolicies": []
+      }
+    },
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores",
+      "apiVersion": "2022-05-01",
+      "name": "[format('{0}acs', parameters('prefix'))]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}', format('{0}kv', parameters('prefix')), 'mysecret2')]",
+      "properties": {
+        "value": "p@55w0rd!"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', format('{0}kv', parameters('prefix')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "ackvs",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "appConfigStoreName": {
+            "value": "[format('{0}acs', parameters('prefix'))]"
+          },
+          "keyVaultName": {
+            "value": "[format('{0}kv', parameters('prefix'))]"
+          },
+          "secretName": {
+            "value": "mysecret1"
+          },
+          "secretValue": {
+            "value": "s3cr3t!"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "4881392564295863085"
+            }
+          },
+          "parameters": {
+            "appConfigKey": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name."
+              }
+            },
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret in Key Vault (either existing or to be created)."
+              }
+            },
+            "secretValue": {
+              "type": "secureString",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault."
+              }
+            },
+            "appConfigStoreName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the App Configuration Store."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Key Vault instance."
+              }
+            },
+            "label": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional label attribute to apply to the App Configuration key-value."
+              }
+            }
+          },
+          "variables": {
+            "secretNameSanitized": "[if(not(empty(parameters('secretValue'))), replace(parameters('secretName'), ':', '--'), parameters('secretName'))]",
+            "sanitisedAppConfigKey": "[format('{0}{1}', replace(replace(uriComponent(if(empty(parameters('appConfigKey')), parameters('secretName'), parameters('appConfigKey'))), '~', '~7E'), '%', '~'), if(empty(parameters('label')), '', format('${0}', parameters('label'))))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+              "apiVersion": "2021-03-01-preview",
+              "name": "[format('{0}/{1}', parameters('appConfigStoreName'), variables('sanitisedAppConfigKey'))]",
+              "properties": {
+                "contentType": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+                "value": "[string(createObject('uri', reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value))]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[variables('secretNameSanitized')]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "secretName": {
+                    "value": "[variables('secretNameSanitized')]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "useExisting": {
+                    "value": "[empty(parameters('secretValue'))]"
+                  },
+                  "contentValue": {
+                    "value": "[if(empty(parameters('secretValue')), '', parameters('secretValue'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.8.9.13224",
+                      "templateHash": "12015994460177070841"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "secureString",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value]",
+              "metadata": {
+                "description": "The secret URI (with version) of the secret backing the App Configuration key-value."
+              }
+            },
+            "appConfigKey": {
+              "type": "string",
+              "value": "[variables('sanitisedAppConfigKey')]",
+              "metadata": {
+                "description": "The key for the App Configuration key-value."
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('{0}acs', parameters('prefix')))]",
+        "[resourceId('Microsoft.KeyVault/vaults', format('{0}kv', parameters('prefix')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "ackvs_existing_secret",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "appConfigStoreName": {
+            "value": "[format('{0}acs', parameters('prefix'))]"
+          },
+          "keyVaultName": {
+            "value": "[format('{0}kv', parameters('prefix'))]"
+          },
+          "secretName": {
+            "value": "mysecret2"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "4881392564295863085"
+            }
+          },
+          "parameters": {
+            "appConfigKey": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name."
+              }
+            },
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret in Key Vault (either existing or to be created)."
+              }
+            },
+            "secretValue": {
+              "type": "secureString",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault."
+              }
+            },
+            "appConfigStoreName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the App Configuration Store."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Key Vault instance."
+              }
+            },
+            "label": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional label attribute to apply to the App Configuration key-value."
+              }
+            }
+          },
+          "variables": {
+            "secretNameSanitized": "[if(not(empty(parameters('secretValue'))), replace(parameters('secretName'), ':', '--'), parameters('secretName'))]",
+            "sanitisedAppConfigKey": "[format('{0}{1}', replace(replace(uriComponent(if(empty(parameters('appConfigKey')), parameters('secretName'), parameters('appConfigKey'))), '~', '~7E'), '%', '~'), if(empty(parameters('label')), '', format('${0}', parameters('label'))))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+              "apiVersion": "2021-03-01-preview",
+              "name": "[format('{0}/{1}', parameters('appConfigStoreName'), variables('sanitisedAppConfigKey'))]",
+              "properties": {
+                "contentType": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+                "value": "[string(createObject('uri', reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value))]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[variables('secretNameSanitized')]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "secretName": {
+                    "value": "[variables('secretNameSanitized')]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "useExisting": {
+                    "value": "[empty(parameters('secretValue'))]"
+                  },
+                  "contentValue": {
+                    "value": "[if(empty(parameters('secretValue')), '', parameters('secretValue'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.8.9.13224",
+                      "templateHash": "12015994460177070841"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "secureString",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value]",
+              "metadata": {
+                "description": "The secret URI (with version) of the secret backing the App Configuration key-value."
+              }
+            },
+            "appConfigKey": {
+              "type": "string",
+              "value": "[variables('sanitisedAppConfigKey')]",
+              "metadata": {
+                "description": "The key for the App Configuration key-value."
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('{0}acs', parameters('prefix')))]",
+        "[resourceId('Microsoft.KeyVault/vaults', format('{0}kv', parameters('prefix')))]"
+      ]
+    }
+  ]
+}

--- a/modules/general/app-config-key-vault-secret/test/main.test.json
+++ b/modules/general/app-config-key-vault-secret/test/main.test.json
@@ -5,11 +5,11 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "2528679654793620450"
+      "templateHash": "4506848463104755171"
     }
   },
   "parameters": {
-    "prefix": {
+    "suffix": {
       "type": "string",
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     },
@@ -22,7 +22,7 @@
     {
       "type": "Microsoft.KeyVault/vaults",
       "apiVersion": "2021-11-01-preview",
-      "name": "[format('{0}kv', parameters('prefix'))]",
+      "name": "[format('kv{0}', parameters('suffix'))]",
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
@@ -36,7 +36,7 @@
     {
       "type": "Microsoft.AppConfiguration/configurationStores",
       "apiVersion": "2022-05-01",
-      "name": "[format('{0}acs', parameters('prefix'))]",
+      "name": "[format('acs{0}', parameters('suffix'))]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Standard"
@@ -45,12 +45,12 @@
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2021-11-01-preview",
-      "name": "[format('{0}/{1}', format('{0}kv', parameters('prefix')), 'mysecret2')]",
+      "name": "[format('{0}/{1}', format('kv{0}', parameters('suffix')), 'mysecret2')]",
       "properties": {
         "value": "p@55w0rd!"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.KeyVault/vaults', format('{0}kv', parameters('prefix')))]"
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]"
       ]
     },
     {
@@ -64,10 +64,10 @@
         "mode": "Incremental",
         "parameters": {
           "appConfigStoreName": {
-            "value": "[format('{0}acs', parameters('prefix'))]"
+            "value": "[format('acs{0}', parameters('suffix'))]"
           },
           "keyVaultName": {
-            "value": "[format('{0}kv', parameters('prefix'))]"
+            "value": "[format('kv{0}', parameters('suffix'))]"
           },
           "secretName": {
             "value": "mysecret1"
@@ -256,8 +256,8 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('{0}acs', parameters('prefix')))]",
-        "[resourceId('Microsoft.KeyVault/vaults', format('{0}kv', parameters('prefix')))]"
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('acs{0}', parameters('suffix')))]",
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]"
       ]
     },
     {
@@ -271,10 +271,10 @@
         "mode": "Incremental",
         "parameters": {
           "appConfigStoreName": {
-            "value": "[format('{0}acs', parameters('prefix'))]"
+            "value": "[format('acs{0}', parameters('suffix'))]"
           },
           "keyVaultName": {
-            "value": "[format('{0}kv', parameters('prefix'))]"
+            "value": "[format('kv{0}', parameters('suffix'))]"
           },
           "secretName": {
             "value": "mysecret2"
@@ -460,8 +460,8 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('{0}acs', parameters('prefix')))]",
-        "[resourceId('Microsoft.KeyVault/vaults', format('{0}kv', parameters('prefix')))]"
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('acs{0}', parameters('suffix')))]",
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]"
       ]
     }
   ]

--- a/modules/general/app-config-key-vault-secret/version.json
+++ b/modules/general/app-config-key-vault-secret/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.0",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/general/app-config-key-vault-secrets/README.md
+++ b/modules/general/app-config-key-vault-secrets/README.md
@@ -1,0 +1,62 @@
+# App Configuration Key Vault Secrets
+
+Adds or updates multiple App Configuration key-values backed by Azure Key Vault secrets.
+
+## Description
+
+This module is an extension of [App Configuration Key Vault Secret](../app-config-key-vault-secret/README.md) which allows you to set multiple App Configuration key-values with references to Azure Key Vault secrets.
+
+## Parameters
+
+| Name                 | Type     | Required | Description                                                                                                                                                           |
+| :------------------- | :------: | :------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appConfigStoreName` | `string` | Yes      | The name of the App Configuration Store.                                                                                                                              |
+| `keyVaultName`       | `string` | Yes      | The name of the Key Vault instance.                                                                                                                                   |
+| `label`              | `string` | No       | Optional label attribute to apply to the App Configuration key-values.                                                                                                |
+| `keyValueSecrets`    | `array`  | Yes      | An array of the key-value secrets to create/update. Expected properties for each item are `appConfigKey`, `secretName`, `secretValue`. See examples for more details. |
+
+## Outputs
+
+| Name       | Type  | Description                                                                                       |
+| :--------- | :---: | :------------------------------------------------------------------------------------------------ |
+| secretUris | array | An array containing each secret URI (with version) for all App Config key-values created/updated. |
+
+## Examples
+
+### Setting multiple key-value secrets
+
+```bicep
+module ackvs 'br:<registry-fqdn>/bicep/general/app-config-key-vault-secrets:<version>' = {
+  name: 'ackvs'
+  params: {
+    appConfigStoreName: 'myappconfigstore'
+    keyVaultName: 'mykeyvault'
+    keyValueSecrets: [
+      // New secret, default App Configuration key
+      {
+        appConfigKey: ''
+        secretName: 'secret1'
+        secretValue: 'p@55w0rd1!'
+      }
+      // New secret, custom App Configuration key
+      {
+        appConfigKey: 'MyPassword'
+        secretName: 'secret2'
+        secretValue: 'p@55w0rd2!'
+      }
+      // Existing secret, default App Configuration key
+      {
+        appConfigKey: ''
+        secretName: 'secret3'
+        secretValue: ''
+      }
+      // Existing secret, custom App Configuration key
+      {
+        appConfigKey: 'MyOtherPassword'
+        secretName: 'secret4'
+        secretValue: ''
+      }
+    ]
+  }
+}
+```

--- a/modules/general/app-config-key-vault-secrets/main.bicep
+++ b/modules/general/app-config-key-vault-secrets/main.bicep
@@ -1,0 +1,37 @@
+@description('The name of the App Configuration Store.')
+param appConfigStoreName string
+
+@description('The name of the Key Vault instance.')
+param keyVaultName string
+
+@description('Optional label attribute to apply to the App Configuration key-values.')
+param label string = ''
+
+@description('An array of the key-value secrets to create/update. Expected properties for each item are `appConfigKey`, `secretName`, `secretValue`. See examples for more details.')
+param keyValueSecrets array
+
+resource app_config_store 'Microsoft.AppConfiguration/configurationStores@2020-06-01' existing = {
+  name: appConfigStoreName
+}
+
+resource key_vault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
+  name: keyVaultName
+}
+
+module key_value_secrets '../app-config-key-vault-secret/main.bicep' = [for kvs in keyValueSecrets: {
+  name: 'key_value_secret_${replace(kvs.secretName, ':', '--')}'
+  params: {
+    appConfigStoreName: appConfigStoreName
+    appConfigKey: kvs.appConfigKey
+    secretName: kvs.secretName
+    secretValue: kvs.secretValue
+    keyVaultName: keyVaultName
+    label: label
+  }
+}]
+
+@description('An array containing each secret URI (with version) for all App Config key-values created/updated.')
+output secretUris array = [for (kv, index) in keyValueSecrets: {
+  appConfigKey: key_value_secrets[index].outputs.appConfigKey
+  secretUriWithVersion: key_value_secrets[index].outputs.secretUriWithVersion
+}]

--- a/modules/general/app-config-key-vault-secrets/main.json
+++ b/modules/general/app-config-key-vault-secrets/main.json
@@ -1,0 +1,268 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "3957105592039732841"
+    }
+  },
+  "parameters": {
+    "appConfigStoreName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Configuration Store."
+      }
+    },
+    "keyVaultName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Key Vault instance."
+      }
+    },
+    "label": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional label attribute to apply to the App Configuration key-values."
+      }
+    },
+    "keyValueSecrets": {
+      "type": "array",
+      "metadata": {
+        "description": "An array of the key-value secrets to create/update. Expected properties for each item are `appConfigKey`, `secretName`, `secretValue`. See examples for more details."
+      }
+    }
+  },
+  "resources": [
+    {
+      "copy": {
+        "name": "key_value_secrets",
+        "count": "[length(parameters('keyValueSecrets'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('key_value_secret_{0}', replace(parameters('keyValueSecrets')[copyIndex()].secretName, ':', '--'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "appConfigStoreName": {
+            "value": "[parameters('appConfigStoreName')]"
+          },
+          "appConfigKey": {
+            "value": "[parameters('keyValueSecrets')[copyIndex()].appConfigKey]"
+          },
+          "secretName": {
+            "value": "[parameters('keyValueSecrets')[copyIndex()].secretName]"
+          },
+          "secretValue": {
+            "value": "[parameters('keyValueSecrets')[copyIndex()].secretValue]"
+          },
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "label": {
+            "value": "[parameters('label')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "4881392564295863085"
+            }
+          },
+          "parameters": {
+            "appConfigKey": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name."
+              }
+            },
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret in Key Vault (either existing or to be created)."
+              }
+            },
+            "secretValue": {
+              "type": "secureString",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault."
+              }
+            },
+            "appConfigStoreName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the App Configuration Store."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Key Vault instance."
+              }
+            },
+            "label": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional label attribute to apply to the App Configuration key-value."
+              }
+            }
+          },
+          "variables": {
+            "secretNameSanitized": "[if(not(empty(parameters('secretValue'))), replace(parameters('secretName'), ':', '--'), parameters('secretName'))]",
+            "sanitisedAppConfigKey": "[format('{0}{1}', replace(replace(uriComponent(if(empty(parameters('appConfigKey')), parameters('secretName'), parameters('appConfigKey'))), '~', '~7E'), '%', '~'), if(empty(parameters('label')), '', format('${0}', parameters('label'))))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+              "apiVersion": "2021-03-01-preview",
+              "name": "[format('{0}/{1}', parameters('appConfigStoreName'), variables('sanitisedAppConfigKey'))]",
+              "properties": {
+                "contentType": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+                "value": "[string(createObject('uri', reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value))]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[variables('secretNameSanitized')]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "secretName": {
+                    "value": "[variables('secretNameSanitized')]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "useExisting": {
+                    "value": "[empty(parameters('secretValue'))]"
+                  },
+                  "contentValue": {
+                    "value": "[if(empty(parameters('secretValue')), '', parameters('secretValue'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.8.9.13224",
+                      "templateHash": "12015994460177070841"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "secureString",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value]",
+              "metadata": {
+                "description": "The secret URI (with version) of the secret backing the App Configuration key-value."
+              }
+            },
+            "appConfigKey": {
+              "type": "string",
+              "value": "[variables('sanitisedAppConfigKey')]",
+              "metadata": {
+                "description": "The key for the App Configuration key-value."
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "secretUris": {
+      "type": "array",
+      "copy": {
+        "count": "[length(parameters('keyValueSecrets'))]",
+        "input": {
+          "appConfigKey": "[reference(resourceId('Microsoft.Resources/deployments', format('key_value_secret_{0}', replace(parameters('keyValueSecrets')[copyIndex()].secretName, ':', '--')))).outputs.appConfigKey.value]",
+          "secretUriWithVersion": "[reference(resourceId('Microsoft.Resources/deployments', format('key_value_secret_{0}', replace(parameters('keyValueSecrets')[copyIndex()].secretName, ':', '--')))).outputs.secretUriWithVersion.value]"
+        }
+      },
+      "metadata": {
+        "description": "An array containing each secret URI (with version) for all App Config key-values created/updated."
+      }
+    }
+  }
+}

--- a/modules/general/app-config-key-vault-secrets/metadata.json
+++ b/modules/general/app-config-key-vault-secrets/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "App Configuration Key Vault Secrets",
+  "summary": "Adds or updates multiple App Configuration key-values backed by Azure Key Vault secrets.",
+  "owner": "endjin"
+}

--- a/modules/general/app-config-key-vault-secrets/test/main.test.bicep
+++ b/modules/general/app-config-key-vault-secrets/test/main.test.bicep
@@ -1,0 +1,77 @@
+param suffix string = uniqueString(resourceGroup().id)
+param location string = resourceGroup().location
+
+resource kv 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
+  name: 'kv${suffix}'
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenant().tenantId
+    accessPolicies: []
+  }
+}
+
+resource acs 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
+  name: 'acs${suffix}'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+}
+
+resource secret3 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
+  parent: kv
+  name: 'secret3'
+  properties: {
+    value: 'p@55w0rd3!'
+  }
+}
+
+resource secret4 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
+  parent: kv
+  name: 'secret4'
+  properties: {
+    value: 'p@55w0rd4!'
+  }
+}
+
+module ackvs '../main.bicep' = {
+  name: 'ackvs'
+  params: {
+    appConfigStoreName: acs.name
+    keyVaultName: kv.name
+    keyValueSecrets: [
+      // New secret, default App Configuration key
+      {
+        appConfigKey: ''
+        secretName: 'secret1'
+        secretValue: 'p@55w0rd1!'
+      }
+      // New secret, custom App Configuration key
+      {
+        appConfigKey: 'MyPassword'
+        secretName: 'secret2'
+        secretValue: 'p@55w0rd2!'
+      }
+      // Existing secret, default App Configuration key
+      {
+        appConfigKey: ''
+        secretName: 'secret3'
+        secretValue: ''
+      }
+      // Existing secret, custom App Configuration key
+      {
+        appConfigKey: 'MyOtherPassword'
+        secretName: 'secret4'
+        secretValue: ''
+      }
+    ]
+  }
+  dependsOn: [
+    secret3
+    secret4
+  ]
+}

--- a/modules/general/app-config-key-vault-secrets/test/main.test.json
+++ b/modules/general/app-config-key-vault-secrets/test/main.test.json
@@ -1,0 +1,385 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "16939679971421280228"
+    }
+  },
+  "parameters": {
+    "suffix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('kv{0}', parameters('suffix'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "tenantId": "[tenant().tenantId]",
+        "accessPolicies": []
+      }
+    },
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores",
+      "apiVersion": "2022-05-01",
+      "name": "[format('acs{0}', parameters('suffix'))]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}', format('kv{0}', parameters('suffix')), 'secret3')]",
+      "properties": {
+        "value": "p@55w0rd3!"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}', format('kv{0}', parameters('suffix')), 'secret4')]",
+      "properties": {
+        "value": "p@55w0rd4!"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "ackvs",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "appConfigStoreName": {
+            "value": "[format('acs{0}', parameters('suffix'))]"
+          },
+          "keyVaultName": {
+            "value": "[format('kv{0}', parameters('suffix'))]"
+          },
+          "keyValueSecrets": {
+            "value": [
+              {
+                "appConfigKey": "",
+                "secretName": "secret1",
+                "secretValue": "p@55w0rd1!"
+              },
+              {
+                "appConfigKey": "MyPassword",
+                "secretName": "secret2",
+                "secretValue": "p@55w0rd2!"
+              },
+              {
+                "appConfigKey": "",
+                "secretName": "secret3",
+                "secretValue": ""
+              },
+              {
+                "appConfigKey": "MyOtherPassword",
+                "secretName": "secret4",
+                "secretValue": ""
+              }
+            ]
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "3957105592039732841"
+            }
+          },
+          "parameters": {
+            "appConfigStoreName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the App Configuration Store."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Key Vault instance."
+              }
+            },
+            "label": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional label attribute to apply to the App Configuration key-values."
+              }
+            },
+            "keyValueSecrets": {
+              "type": "array",
+              "metadata": {
+                "description": "An array of the key-value secrets to create/update. Expected properties for each item are `appConfigKey`, `secretName`, `secretValue`. See examples for more details."
+              }
+            }
+          },
+          "resources": [
+            {
+              "copy": {
+                "name": "key_value_secrets",
+                "count": "[length(parameters('keyValueSecrets'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[format('key_value_secret_{0}', replace(parameters('keyValueSecrets')[copyIndex()].secretName, ':', '--'))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "appConfigStoreName": {
+                    "value": "[parameters('appConfigStoreName')]"
+                  },
+                  "appConfigKey": {
+                    "value": "[parameters('keyValueSecrets')[copyIndex()].appConfigKey]"
+                  },
+                  "secretName": {
+                    "value": "[parameters('keyValueSecrets')[copyIndex()].secretName]"
+                  },
+                  "secretValue": {
+                    "value": "[parameters('keyValueSecrets')[copyIndex()].secretValue]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "label": {
+                    "value": "[parameters('label')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.8.9.13224",
+                      "templateHash": "4881392564295863085"
+                    }
+                  },
+                  "parameters": {
+                    "appConfigKey": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional value for the key in App Configuration. If left blank, the key will be set to the (sanitized) secret name."
+                      }
+                    },
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the secret in Key Vault (either existing or to be created)."
+                      }
+                    },
+                    "secretValue": {
+                      "type": "secureString",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional value to set as the secret. If left blank, a secret with the provided `secretName` must already exist in Key Vault."
+                      }
+                    },
+                    "appConfigStoreName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the App Configuration Store."
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Key Vault instance."
+                      }
+                    },
+                    "label": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional label attribute to apply to the App Configuration key-value."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "secretNameSanitized": "[if(not(empty(parameters('secretValue'))), replace(parameters('secretName'), ':', '--'), parameters('secretName'))]",
+                    "sanitisedAppConfigKey": "[format('{0}{1}', replace(replace(uriComponent(if(empty(parameters('appConfigKey')), parameters('secretName'), parameters('appConfigKey'))), '~', '~7E'), '%', '~'), if(empty(parameters('label')), '', format('${0}', parameters('label'))))]"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+                      "apiVersion": "2021-03-01-preview",
+                      "name": "[format('{0}/{1}', parameters('appConfigStoreName'), variables('sanitisedAppConfigKey'))]",
+                      "properties": {
+                        "contentType": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+                        "value": "[string(createObject('uri', reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value))]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2020-10-01",
+                      "name": "[variables('secretNameSanitized')]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "secretName": {
+                            "value": "[variables('secretNameSanitized')]"
+                          },
+                          "keyVaultName": {
+                            "value": "[parameters('keyVaultName')]"
+                          },
+                          "useExisting": {
+                            "value": "[empty(parameters('secretValue'))]"
+                          },
+                          "contentValue": {
+                            "value": "[if(empty(parameters('secretValue')), '', parameters('secretValue'))]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.8.9.13224",
+                              "templateHash": "12015994460177070841"
+                            }
+                          },
+                          "parameters": {
+                            "secretName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Enter the secret name."
+                              }
+                            },
+                            "contentType": {
+                              "type": "string",
+                              "defaultValue": "text/plain",
+                              "metadata": {
+                                "description": "Type of the secret"
+                              }
+                            },
+                            "contentValue": {
+                              "type": "secureString",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Value of the secret"
+                              }
+                            },
+                            "keyVaultName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Name of the vault"
+                              }
+                            },
+                            "useExisting": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "When true, a pre-existing secret will be returned"
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "condition": "[not(parameters('useExisting'))]",
+                              "type": "Microsoft.KeyVault/vaults/secrets",
+                              "apiVersion": "2021-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                              "properties": {
+                                "contentType": "[parameters('contentType')]",
+                                "value": "[parameters('contentValue')]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "secretUriWithVersion": {
+                              "type": "string",
+                              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                              "metadata": {
+                                "description": "The key vault URI linking to the new/updated secret"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('secretNameSanitized'))).outputs.secretUriWithVersion.value]",
+                      "metadata": {
+                        "description": "The secret URI (with version) of the secret backing the App Configuration key-value."
+                      }
+                    },
+                    "appConfigKey": {
+                      "type": "string",
+                      "value": "[variables('sanitisedAppConfigKey')]",
+                      "metadata": {
+                        "description": "The key for the App Configuration key-value."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "secretUris": {
+              "type": "array",
+              "copy": {
+                "count": "[length(parameters('keyValueSecrets'))]",
+                "input": {
+                  "appConfigKey": "[reference(resourceId('Microsoft.Resources/deployments', format('key_value_secret_{0}', replace(parameters('keyValueSecrets')[copyIndex()].secretName, ':', '--')))).outputs.appConfigKey.value]",
+                  "secretUriWithVersion": "[reference(resourceId('Microsoft.Resources/deployments', format('key_value_secret_{0}', replace(parameters('keyValueSecrets')[copyIndex()].secretName, ':', '--')))).outputs.secretUriWithVersion.value]"
+                }
+              },
+              "metadata": {
+                "description": "An array containing each secret URI (with version) for all App Config key-values created/updated."
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', format('acs{0}', parameters('suffix')))]",
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]",
+        "[resourceId('Microsoft.KeyVault/vaults/secrets', format('kv{0}', parameters('suffix')), 'secret3')]",
+        "[resourceId('Microsoft.KeyVault/vaults/secrets', format('kv{0}', parameters('suffix')), 'secret4')]"
+      ]
+    }
+  ]
+}

--- a/modules/general/app-config-key-vault-secrets/version.json
+++ b/modules/general/app-config-key-vault-secrets/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.0",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}


### PR DESCRIPTION
This PR adds 2 new modules:
- `app-config-key-vault-secret` for adding an individual secret-backed key-value
- `app-config-key-vault-secrets` for adding multiple secret-backed key-values

Closes #23 , closes #24 