### PR TITLE
Add Private DNS modules 

### DIFF
--- a/modules/general/private-dns-cname/README.md
+++ b/modules/general/private-dns-cname/README.md
@@ -1,0 +1,66 @@
+# Private DNS CNAME
+
+Adds/updates a CNAME record in an existing private DNS zone
+
+## Description
+
+Creates a new [CNAME record](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records#cname-records) in the provided existing private DNS zone.
+
+## Parameters
+
+| Name             | Type     | Required | Description                                                                      |
+| :--------------- | :------: | :------: | :------------------------------------------------------------------------------- |
+| `zoneName`       | `string` | Yes      | Name of existing private DNS zone that the CNAME record will be associated with. |
+| `recordName`     | `string` | Yes      | The resource name for the CNAME record.                                          |
+| `recordValue`    | `string` | Yes      | The value for the CNAME record.                                                  |
+| `recordMetadata` | `object` | No       | Key-value pair metadata associated with the CNAME record.                        |
+| `recordTtl`      | `int`    | No       | The TTL (time-to-live) for the CNAME record, in seconds.                         |
+
+## Outputs
+
+| Name | Type | Description |
+| :--- | :--: | :---------- |
+
+## Examples
+
+### Add CNAME records for Synapse SQL-related private endpoints
+
+```bicep
+var sqlPrivateLinkFqdn = 'privatelink${environment().suffixes.sqlServerHostname}'
+
+module privatedns_zone 'br:<registry-fqdn>/bicep/general/private-dns-zone:<version>' = {
+  name: '${zone}-privateDnsDeploy'
+  params: {
+    zoneName: sqlPrivateLinkFqdn
+    virtualNetworkResourceGroupName: 'my-vnet-rg'
+    virtualNetworkName: 'myvnet'
+    autoRegistrationEnabled: false
+  }
+}
+
+var synapseWorkspaceName = 'mysynapseworkspace'
+
+module sql_cname_records 'br:<registry-fqdn>/bicep/general/private-dns-cname:<version>' = {
+  name: 'sqlCNameDeploy'
+  params: {
+    recordName: synapseWorkspaceName
+    recordValue: '${synapseWorkspaceName}.privatelink.sql.azuresynapse.net'
+    zoneName: sqlPrivateLinkFqdn
+    recordMetadata: {
+      creator: 'Created to support private endpoint access to Azure Synapse SQL Pools'
+    }
+  }
+}
+
+module sqlondemand_cname_records 'br:<registry-fqdn>/bicep/general/private-dns-cname:<version>' = {
+  name: 'sqlOnDemandCNameDeploy'
+  params: {
+    recordName: '${synapseWorkspaceName}-ondemand'
+    recordValue: '${synapseWorkspaceName}-ondemand.privatelink.sql.azuresynapse.net'
+    zoneName: sqlPrivateLinkFqdn
+    recordMetadata: {
+      creator: 'Created to support private endpoint access to Azure Synapse SQL Pools'
+    }
+  }
+}
+```

--- a/modules/general/private-dns-cname/main.bicep
+++ b/modules/general/private-dns-cname/main.bicep
@@ -1,0 +1,30 @@
+@description('Name of existing private DNS zone that the CNAME record will be associated with.')
+param zoneName string
+
+@description('The resource name for the CNAME record.')
+param recordName string
+
+@description('The value for the CNAME record.')
+param recordValue string
+
+@description('Key-value pair metadata associated with the CNAME record.')
+param recordMetadata object = {}
+
+@description('The TTL (time-to-live) for the CNAME record, in seconds.')
+param recordTtl int = 10
+
+resource private_dns_zone 'Microsoft.Network/privateDnsZones@2020-06-01' existing = {
+  name: zoneName
+}
+
+resource cname_record 'Microsoft.Network/privateDnsZones/CNAME@2020-06-01' = {
+  parent: private_dns_zone
+  name: recordName
+  properties: {
+    cnameRecord: {
+      cname: recordValue
+    }
+    metadata: recordMetadata
+    ttl: recordTtl
+  }
+}

--- a/modules/general/private-dns-cname/main.json
+++ b/modules/general/private-dns-cname/main.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "6236435900649272331"
+    }
+  },
+  "parameters": {
+    "zoneName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of existing private DNS zone that the CNAME record will be associated with."
+      }
+    },
+    "recordName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource name for the CNAME record."
+      }
+    },
+    "recordValue": {
+      "type": "string",
+      "metadata": {
+        "description": "The value for the CNAME record."
+      }
+    },
+    "recordMetadata": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Key-value pair metadata associated with the CNAME record."
+      }
+    },
+    "recordTtl": {
+      "type": "int",
+      "defaultValue": 10,
+      "metadata": {
+        "description": "The TTL (time-to-live) for the CNAME record, in seconds."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/privateDnsZones/CNAME",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('zoneName'), parameters('recordName'))]",
+      "properties": {
+        "cnameRecord": {
+          "cname": "[parameters('recordValue')]"
+        },
+        "metadata": "[parameters('recordMetadata')]",
+        "ttl": "[parameters('recordTtl')]"
+      }
+    }
+  ]
+}

--- a/modules/general/private-dns-cname/metadata.json
+++ b/modules/general/private-dns-cname/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Private DNS CNAME",
+  "summary": "Adds/updates a CNAME record in an existing private DNS zone",
+  "owner": "endjin"
+}

--- a/modules/general/private-dns-cname/test/main.test.bicep
+++ b/modules/general/private-dns-cname/test/main.test.bicep
@@ -1,0 +1,46 @@
+param prefix string = uniqueString(resourceGroup().id)
+param location string = resourceGroup().location
+
+var virtualNetworkName = '${prefix}vnet'
+var virtualNetworkResourceGroupName = resourceGroup().name
+
+resource vnet 'Microsoft.Network/virtualNetworks@2021-08-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+}
+
+var sqlPrivateLinkFqdn = 'privatelink${environment().suffixes.sqlServerHostname}'
+
+module privatedns_zones '../../private-dns-zone/main.bicep' = {
+  name: 'privateDnsDeploy'
+  params: {
+    zoneName: sqlPrivateLinkFqdn
+    virtualNetworkResourceGroupName: virtualNetworkResourceGroupName
+    virtualNetworkName: virtualNetworkName
+    autoRegistrationEnabled: false
+  }
+  dependsOn: [
+    vnet
+  ]
+}
+
+var synapseWorkspaceName = '${prefix}synapse'
+
+module privatedns_cnamerecord '../main.bicep' = {
+  name: 'cnameRecordDeploy'
+  params: {
+    recordName: synapseWorkspaceName
+    recordValue: '${synapseWorkspaceName}.privatelink.sql.azuresynapse.net'
+    zoneName: sqlPrivateLinkFqdn
+    recordMetadata: {
+      creator: 'Created to support private endpoint access to Azure Synapse SQL Pools'
+    }
+  }
+}

--- a/modules/general/private-dns-cname/test/main.test.json
+++ b/modules/general/private-dns-cname/test/main.test.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "11798965199465267512"
+    }
+  },
+  "parameters": {
+    "prefix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "variables": {
+    "virtualNetworkName": "[format('{0}vnet', parameters('prefix'))]",
+    "virtualNetworkResourceGroupName": "[resourceGroup().name]",
+    "sqlPrivateLinkFqdn": "[format('privatelink{0}', environment().suffixes.sqlServerHostname)]",
+    "synapseWorkspaceName": "[format('{0}synapse', parameters('prefix'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-08-01",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "privateDnsDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "zoneName": {
+            "value": "[variables('sqlPrivateLinkFqdn')]"
+          },
+          "virtualNetworkResourceGroupName": {
+            "value": "[variables('virtualNetworkResourceGroupName')]"
+          },
+          "virtualNetworkName": {
+            "value": "[variables('virtualNetworkName')]"
+          },
+          "autoRegistrationEnabled": {
+            "value": false
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "12484281000366007501"
+            }
+          },
+          "parameters": {
+            "zoneName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name for the Private DNS Zone. Must be a valid domain name. For Azure services, use the recommended zone names (ref: https://learn.microsoft.com/en-gb/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration)"
+              }
+            },
+            "autoRegistrationEnabled": {
+              "type": "bool",
+              "metadata": {
+                "description": "When true, a DNS record gets automatically created for each virtual machine deployed in the virtual network."
+              }
+            },
+            "virtualNetworkResourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group name of the existing VNet."
+              }
+            },
+            "virtualNetworkName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the existing VNet."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('zoneName')]",
+              "location": "global"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', parameters('zoneName'), format('{0}-link', parameters('zoneName')))]",
+              "location": "global",
+              "properties": {
+                "registrationEnabled": "[parameters('autoRegistrationEnabled')]",
+                "virtualNetwork": {
+                  "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('virtualNetworkResourceGroupName')), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', parameters('zoneName'))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "cnameRecordDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "recordName": {
+            "value": "[variables('synapseWorkspaceName')]"
+          },
+          "recordValue": {
+            "value": "[format('{0}.privatelink.sql.azuresynapse.net', variables('synapseWorkspaceName'))]"
+          },
+          "zoneName": {
+            "value": "[variables('sqlPrivateLinkFqdn')]"
+          },
+          "recordMetadata": {
+            "value": {
+              "creator": "Created to support private endpoint access to Azure Synapse SQL Pools"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "6236435900649272331"
+            }
+          },
+          "parameters": {
+            "zoneName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of existing private DNS zone that the CNAME record will be associated with."
+              }
+            },
+            "recordName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource name for the CNAME record."
+              }
+            },
+            "recordValue": {
+              "type": "string",
+              "metadata": {
+                "description": "The value for the CNAME record."
+              }
+            },
+            "recordMetadata": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Key-value pair metadata associated with the CNAME record."
+              }
+            },
+            "recordTtl": {
+              "type": "int",
+              "defaultValue": 10,
+              "metadata": {
+                "description": "The TTL (time-to-live) for the CNAME record, in seconds."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/privateDnsZones/CNAME",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', parameters('zoneName'), parameters('recordName'))]",
+              "properties": {
+                "cnameRecord": {
+                  "cname": "[parameters('recordValue')]"
+                },
+                "metadata": "[parameters('recordMetadata')]",
+                "ttl": "[parameters('recordTtl')]"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/modules/general/private-dns-cname/version.json
+++ b/modules/general/private-dns-cname/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.0",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/general/private-dns-zone/README.md
+++ b/modules/general/private-dns-zone/README.md
@@ -1,0 +1,37 @@
+# Private DNS Zone
+
+Adds/updates a private DNS zone and virtual network link for existing VNet
+
+## Description
+
+Creates a [private Azure DNS zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone) and links the zone to an existing virtual network.
+
+## Parameters
+
+| Name                              | Type     | Required | Description                                                                                                                                                                                                                               |
+| :-------------------------------- | :------: | :------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `zoneName`                        | `string` | Yes      | The name for the Private DNS Zone. Must be a valid domain name. For Azure services, use the recommended zone names (ref: https://learn.microsoft.com/en-gb/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration) |
+| `autoRegistrationEnabled`         | `bool`   | Yes      | When true, a DNS record gets automatically created for each virtual machine deployed in the virtual network.                                                                                                                              |
+| `virtualNetworkResourceGroupName` | `string` | Yes      | The resource group name of the existing VNet.                                                                                                                                                                                             |
+| `virtualNetworkName`              | `string` | Yes      | The name of the existing VNet.                                                                                                                                                                                                            |
+
+## Outputs
+
+| Name | Type | Description |
+| :--- | :--: | :---------- |
+
+## Examples
+
+### Private DNS Zone for Azure SQL private endpoint
+
+```bicep
+module privatedns_zone 'br:<registry-fqdn>/bicep/general/private-dns-zone:<version>' = {
+  name: '${zone}-privateDnsDeploy'
+  params: {
+    zoneName: 'privatelink${environment().suffixes.sqlServerHostname}'
+    virtualNetworkResourceGroupName: 'my-vnet-rg'
+    virtualNetworkName: 'myvnet'
+    autoRegistrationEnabled: false
+  }
+}
+```

--- a/modules/general/private-dns-zone/main.bicep
+++ b/modules/general/private-dns-zone/main.bicep
@@ -1,0 +1,33 @@
+@description('The name for the Private DNS Zone. Must be a valid domain name. For Azure services, use the recommended zone names (ref: https://learn.microsoft.com/en-gb/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration)')
+param zoneName string
+
+@description('When true, a DNS record gets automatically created for each virtual machine deployed in the virtual network.')
+param autoRegistrationEnabled bool
+
+@description('The resource group name of the existing VNet.')
+param virtualNetworkResourceGroupName string
+
+@description('The name of the existing VNet.')
+param virtualNetworkName string
+
+resource vnet 'Microsoft.Network/virtualNetworks@2021-08-01' existing = {
+  name: virtualNetworkName
+  scope: resourceGroup(virtualNetworkResourceGroupName)
+}
+
+resource privatedns_zone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: zoneName
+  location: 'global'
+}
+
+resource privatedns_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privatedns_zone
+  name: '${privatedns_zone.name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: autoRegistrationEnabled
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}

--- a/modules/general/private-dns-zone/main.json
+++ b/modules/general/private-dns-zone/main.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "12484281000366007501"
+    }
+  },
+  "parameters": {
+    "zoneName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name for the Private DNS Zone. Must be a valid domain name. For Azure services, use the recommended zone names (ref: https://learn.microsoft.com/en-gb/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration)"
+      }
+    },
+    "autoRegistrationEnabled": {
+      "type": "bool",
+      "metadata": {
+        "description": "When true, a DNS record gets automatically created for each virtual machine deployed in the virtual network."
+      }
+    },
+    "virtualNetworkResourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group name of the existing VNet."
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the existing VNet."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('zoneName')]",
+      "location": "global"
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('zoneName'), format('{0}-link', parameters('zoneName')))]",
+      "location": "global",
+      "properties": {
+        "registrationEnabled": "[parameters('autoRegistrationEnabled')]",
+        "virtualNetwork": {
+          "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('virtualNetworkResourceGroupName')), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', parameters('zoneName'))]"
+      ]
+    }
+  ]
+}

--- a/modules/general/private-dns-zone/metadata.json
+++ b/modules/general/private-dns-zone/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Private DNS Zone",
+  "summary": "Adds/updates a private DNS zone and virtual network link for existing VNet",
+  "owner": "endjin"
+}

--- a/modules/general/private-dns-zone/test/main.test.bicep
+++ b/modules/general/private-dns-zone/test/main.test.bicep
@@ -1,0 +1,30 @@
+param prefix string = uniqueString(resourceGroup().id)
+param location string = resourceGroup().location
+
+var virtualNetworkName = '${prefix}vnet'
+var virtualNetworkResourceGroupName = resourceGroup().name
+
+resource vnet 'Microsoft.Network/virtualNetworks@2021-08-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+}
+
+module privatedns_zones '../main.bicep' = {
+  name: 'privateDnsDeploy'
+  params: {
+    zoneName: 'privatelink${environment().suffixes.sqlServerHostname}'
+    virtualNetworkResourceGroupName: virtualNetworkResourceGroupName
+    virtualNetworkName: virtualNetworkName
+    autoRegistrationEnabled: false
+  }
+  dependsOn: [
+    vnet
+  ]
+}

--- a/modules/general/private-dns-zone/test/main.test.json
+++ b/modules/general/private-dns-zone/test/main.test.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "3447476062970437165"
+    }
+  },
+  "parameters": {
+    "prefix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "variables": {
+    "virtualNetworkName": "[format('{0}vnet', parameters('prefix'))]",
+    "virtualNetworkResourceGroupName": "[resourceGroup().name]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-08-01",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "privateDnsDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "zoneName": {
+            "value": "[format('privatelink{0}', environment().suffixes.sqlServerHostname)]"
+          },
+          "virtualNetworkResourceGroupName": {
+            "value": "[variables('virtualNetworkResourceGroupName')]"
+          },
+          "virtualNetworkName": {
+            "value": "[variables('virtualNetworkName')]"
+          },
+          "autoRegistrationEnabled": {
+            "value": false
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.8.9.13224",
+              "templateHash": "12484281000366007501"
+            }
+          },
+          "parameters": {
+            "zoneName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name for the Private DNS Zone. Must be a valid domain name. For Azure services, use the recommended zone names (ref: https://learn.microsoft.com/en-gb/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration)"
+              }
+            },
+            "autoRegistrationEnabled": {
+              "type": "bool",
+              "metadata": {
+                "description": "When true, a DNS record gets automatically created for each virtual machine deployed in the virtual network."
+              }
+            },
+            "virtualNetworkResourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group name of the existing VNet."
+              }
+            },
+            "virtualNetworkName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the existing VNet."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('zoneName')]",
+              "location": "global"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', parameters('zoneName'), format('{0}-link', parameters('zoneName')))]",
+              "location": "global",
+              "properties": {
+                "registrationEnabled": "[parameters('autoRegistrationEnabled')]",
+                "virtualNetwork": {
+                  "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('virtualNetworkResourceGroupName')), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', parameters('zoneName'))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
+    }
+  ]
+}

--- a/modules/general/private-dns-zone/version.json
+++ b/modules/general/private-dns-zone/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.0",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}


### PR DESCRIPTION
This PR adds 2 new modules:
- `private-dns-zone` for creating a private DNS zone and virtual network link for an existing VNet
- `private-dns-cname` for creating a CNAME record in an existing private DNS zone

Closes #32