### PR TITLE
Ensure unique deployment names when configuring key vault diagnostics

### DIFF
--- a/modules/general/app-config-key-vault-secrets/main.bicep
+++ b/modules/general/app-config-key-vault-secrets/main.bicep
@@ -21,11 +21,11 @@ resource key_vault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
 module key_value_secrets '../app-config-key-vault-secret/main.bicep' = [for kvs in keyValueSecrets: {
   name: 'key_value_secret_${replace(kvs.secretName, ':', '--')}'
   params: {
-    appConfigStoreName: appConfigStoreName
+    appConfigStoreName: app_config_store.name
     appConfigKey: kvs.appConfigKey
     secretName: kvs.secretName
     secretValue: kvs.secretValue
-    keyVaultName: keyVaultName
+    keyVaultName: key_vault.name
     label: label
   }
 }]

--- a/modules/general/key-vault-with-secrets-access-via-groups/main.bicep
+++ b/modules/general/key-vault-with-secrets-access-via-groups/main.bicep
@@ -14,6 +14,7 @@ param name string
 param sku string = 'standard'
 
 @description('The AzureAD objectId for the group to be granted "get" access to secrets')
+#disable-next-line secure-secrets-in-params
 param secretsReadersGroupObjectId string
 
 @description('The list of secret permissions granted to the "reader" group')
@@ -21,6 +22,7 @@ param secretsReadersPermissions array = [
   'get'
 ]
 @description('The AzureAD objectId for the group to be granted "get" & "set" access to secrets')
+#disable-next-line secure-secrets-in-params
 param secretsContributorsGroupObjectId string
 
 @description('The list of secret permissions granted to the "contributors" group')

--- a/modules/general/key-vault-with-secrets-access-via-groups/main.json
+++ b/modules/general/key-vault-with-secrets-access-via-groups/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.11.1.770",
-      "templateHash": "5326432420576387653"
+      "templateHash": "14496973688496895959"
     }
   },
   "parameters": {
@@ -227,7 +227,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.11.1.770",
-              "templateHash": "14332771442205223118"
+              "templateHash": "6548570452889463336"
             }
           },
           "parameters": {
@@ -385,7 +385,7 @@
               "condition": "[parameters('enableDiagnostics')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
-              "name": "kvDiagnosticsDeploy",
+              "name": "[format('kvDiagnosticsDeploy-{0}', parameters('name'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"

--- a/modules/general/key-vault/main.bicep
+++ b/modules/general/key-vault/main.bicep
@@ -91,7 +91,7 @@ resource key_vault 'Microsoft.KeyVault/vaults@2021-06-01-preview' = if (!useExis
 }
 
 module diagnostics 'diagnostics.bicep' = if (enableDiagnostics) {
-  name: 'kvDiagnosticsDeploy'
+  name: 'kvDiagnosticsDeploy-${name}'
   params: {
     location: location
     keyVaultName: name

--- a/modules/general/key-vault/main.json
+++ b/modules/general/key-vault/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.11.1.770",
-      "templateHash": "14332771442205223118"
+      "templateHash": "6548570452889463336"
     }
   },
   "parameters": {
@@ -163,7 +163,7 @@
       "condition": "[parameters('enableDiagnostics')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
-      "name": "kvDiagnosticsDeploy",
+      "name": "[format('kvDiagnosticsDeploy-{0}', parameters('name'))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"


### PR DESCRIPTION
This is to avoid issues when multiple key vaults are deployed to the same resource group.