### PR TITLE
Fix `synapse-workspace` module to fully adhere to `enablePrivateEndpointsPrivateDns` option

### DIFF
--- a/modules/general/synapse-workspace/main.bicep
+++ b/modules/general/synapse-workspace/main.bicep
@@ -244,7 +244,7 @@ module private_endpoints '../private-endpoint/main.bicep' = [ for service in ena
 // private endpoint as the Synapse SQL-related services seem unable to 
 // register themselves on that domain.
 //
-module sql_cname_records '../private-dns-cname/main.bicep' = if (contains(enabledSynapsePrivateEndpointServices, 'sql')) {
+module sql_cname_records '../private-dns-cname/main.bicep' = if (enablePrivateEndpointsPrivateDns && contains(enabledSynapsePrivateEndpointServices, 'sql')) {
   name: 'sqlCNameDeploy'
   scope: resourceGroup(virtualNetworkSubscriptionId, virtualNetworkResourceGroupName)
   params: {
@@ -257,7 +257,7 @@ module sql_cname_records '../private-dns-cname/main.bicep' = if (contains(enable
   }
 }
 
-module sqlondemand_cname_records '../private-dns-cname/main.bicep' = if (contains(enabledSynapsePrivateEndpointServices, 'sqlOnDemand')) {
+module sqlondemand_cname_records '../private-dns-cname/main.bicep' = if (enablePrivateEndpointsPrivateDns && contains(enabledSynapsePrivateEndpointServices, 'sqlOnDemand')) {
   name: 'sqlOnDemandCNameDeploy'
   scope: resourceGroup(virtualNetworkSubscriptionId, virtualNetworkResourceGroupName)
   params: {

--- a/modules/general/synapse-workspace/main.json
+++ b/modules/general/synapse-workspace/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "11341876715866713067"
+      "templateHash": "889132120880867717"
     }
   },
   "parameters": {
@@ -2256,7 +2256,7 @@
       ]
     },
     {
-      "condition": "[contains(parameters('enabledSynapsePrivateEndpointServices'), 'sql')]",
+      "condition": "[and(parameters('enablePrivateEndpointsPrivateDns'), contains(parameters('enabledSynapsePrivateEndpointServices'), 'sql'))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "sqlCNameDeploy",
@@ -2348,7 +2348,7 @@
       ]
     },
     {
-      "condition": "[contains(parameters('enabledSynapsePrivateEndpointServices'), 'sqlOnDemand')]",
+      "condition": "[and(parameters('enablePrivateEndpointsPrivateDns'), contains(parameters('enabledSynapsePrivateEndpointServices'), 'sqlOnDemand'))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "sqlOnDemandCNameDeploy",


### PR DESCRIPTION
Do not try to create CNAME PrivateDNS records when the associated flag is disabled