### PR TITLE
Updates to `app-insights-with-config-publish` module

### DIFF
--- a/modules/general/app-insights-with-config-publish/README.md
+++ b/modules/general/app-insights-with-config-publish/README.md
@@ -10,29 +10,33 @@ If the resource is expected to already exist, the `useExisting` flag should be u
 
 ## Parameters
 
-| Name                                     | Type     | Required | Description                                                                                                                                |
-| :--------------------------------------- | :------: | :------: | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                   | `string` | Yes      | The name of the app insights workspace                                                                                                     |
-| `subscriptionId`                         | `string` | No       | The subscription of the existing app insights workspace                                                                                    |
-| `location`                               | `string` | Yes      | The location of the app insights workspace                                                                                                 |
-| `logAnalyticsWorkspaceName`              | `string` | Yes      | The name of the existing Log Analytics workspace which the data will be ingested to.                                                       |
-| `disablePublicNetworkAccessForIngestion` | `bool`   | No       | When true, public network access is disabled for ingestion of data.                                                                        |
-| `disablePublicNetworkAccessForQuery`     | `bool`   | No       | When true, public network access is disabled for querying of data.                                                                         |
-| `keyVaultName`                           | `string` | Yes      | The key vault name where the instrumentation key will be stored                                                                            |
-| `keyVaultResourceGroupName`              | `string` | Yes      | The resource group of the key vault where the instrumentation key will be stored                                                           |
-| `keyVaultSubscriptionId`                 | `string` | No       | The subscription of the key vault where the instrumentation key will be stored                                                             |
-| `kind`                                   | `string` | No       | The kind of application using the workspace                                                                                                |
-| `applicationType`                        | `string` | No       | The type of application using the workspace                                                                                                |
-| `useExisting`                            | `bool`   | No       | When true, the details of an existing app configuration store will be returned; When false, the app configuration store is created/updated |
-| `resourceTags`                           | `object` | No       | The resource tags applied to resources                                                                                                     |
+| Name                                            | Type     | Required | Description                                                                                                                                |
+| :---------------------------------------------- | :------: | :------: | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                          | `string` | Yes      | The name of the app insights workspace                                                                                                     |
+| `subscriptionId`                                | `string` | No       | The subscription of the existing app insights workspace                                                                                    |
+| `location`                                      | `string` | Yes      | The location of the app insights workspace                                                                                                 |
+| `logAnalyticsWorkspaceName`                     | `string` | Yes      | The name of the existing Log Analytics workspace which the data will be ingested to.                                                       |
+| `disablePublicNetworkAccessForIngestion`        | `bool`   | No       | When true, public network access is disabled for ingestion of data.                                                                        |
+| `disablePublicNetworkAccessForQuery`            | `bool`   | No       | When true, public network access is disabled for querying of data.                                                                         |
+| `keyVaultName`                                  | `string` | Yes      | The key vault name where the instrumentation key will be stored                                                                            |
+| `keyVaultResourceGroupName`                     | `string` | Yes      | The resource group of the key vault where the instrumentation key will be stored                                                           |
+| `keyVaultSubscriptionId`                        | `string` | No       | The subscription of the key vault where the instrumentation key will be stored                                                             |
+| `applicationInsightsKeySecretName`              | `string` | No       | The name of the key vault secret where the instrumentation key will be stored.                                                             |
+| `applicationInsightsConnectionStringSecretName` | `string` | No       | The name of the key vault secret where the connection string will be stored.                                                               |
+| `kind`                                          | `string` | No       | The kind of application using the workspace                                                                                                |
+| `applicationType`                               | `string` | No       | The type of application using the workspace                                                                                                |
+| `useExisting`                                   | `bool`   | No       | When true, the details of an existing app configuration store will be returned; When false, the app configuration store is created/updated |
+| `resourceTags`                                  | `object` | No       | The resource tags applied to resources                                                                                                     |
 
 ## Outputs
 
-| Name                         | Type   | Description                                                |
-| :--------------------------- | :----: | :--------------------------------------------------------- |
-| id                           | string | The resource ID of the app insights workspace              |
-| name                         | string | The name of the app insights workspace                     |
-| appInsightsWorkspaceResource | object | An object representing the app insights workspace resource |
+| Name                                  | Type   | Description                                                                    |
+| :------------------------------------ | :----: | :----------------------------------------------------------------------------- |
+| id                                    | string | The resource ID of the app insights workspace                                  |
+| name                                  | string | The name of the app insights workspace                                         |
+| appInsightsWorkspaceResource          | object | An object representing the app insights workspace resource                     |
+| appInsightsKeySecretName              | string | The name of the key vault secret where the instrumentation key will be stored. |
+| appInsightsConnectionStringSecretName | string | The name of the key vault secret where the connection string will be stored.   |
 
 ## Examples
 

--- a/modules/general/app-insights-with-config-publish/main.bicep
+++ b/modules/general/app-insights-with-config-publish/main.bicep
@@ -29,6 +29,12 @@ param keyVaultResourceGroupName string
 @description('The subscription of the key vault where the instrumentation key will be stored')
 param keyVaultSubscriptionId string = subscriptionId
 
+@description('The name of the key vault secret where the instrumentation key will be stored.')
+param applicationInsightsKeySecretName string = 'AppInsightsInstrumentationKey'
+
+@description('The name of the key vault secret where the connection string will be stored.')
+param applicationInsightsConnectionStringSecretName string = 'AppInsightsConnectionString'
+
 @description('The kind of application using the workspace')
 @allowed([
   'web'
@@ -77,8 +83,19 @@ module aikey_secret '../key-vault-secret/main.bicep' = {
   scope: resourceGroup(keyVaultSubscriptionId, keyVaultResourceGroupName)
   params: {
     keyVaultName: keyVaultName
-    secretName: 'AppInsightsInstrumentationKey'
+    secretName: applicationInsightsKeySecretName
     contentValue: app_insights.outputs.appInsightsWorkspaceResource.properties.InstrumentationKey
+    contentType: 'text/plain'
+  }
+}
+
+module aiconnectionstring_secret '../key-vault-secret/main.bicep' = {
+  name: 'appInsightsConnectionStringSecret'
+  scope: resourceGroup(keyVaultSubscriptionId, keyVaultResourceGroupName)
+  params: {
+    keyVaultName: keyVaultName
+    secretName: applicationInsightsConnectionStringSecretName
+    contentValue: app_insights.outputs.appInsightsWorkspaceResource.properties.ConnectionString
     contentType: 'text/plain'
   }
 }
@@ -92,3 +109,8 @@ output name string = app_insights.outputs.name
 // Returns the full AppInsights wWrkspace resource object (workaround whilst resource types cannot be returned directly)
 @description('An object representing the app insights workspace resource')
 output appInsightsWorkspaceResource object = app_insights.outputs.appInsightsWorkspaceResource
+
+@description('The name of the key vault secret where the instrumentation key will be stored.')
+output appInsightsKeySecretName string = applicationInsightsKeySecretName
+@description('The name of the key vault secret where the connection string will be stored.')
+output appInsightsConnectionStringSecretName string = applicationInsightsConnectionStringSecretName

--- a/modules/general/app-insights-with-config-publish/main.json
+++ b/modules/general/app-insights-with-config-publish/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "13189411548288609539"
+      "templateHash": "11713654580158639840"
     }
   },
   "parameters": {
@@ -65,6 +65,20 @@
       "defaultValue": "[parameters('subscriptionId')]",
       "metadata": {
         "description": "The subscription of the key vault where the instrumentation key will be stored"
+      }
+    },
+    "applicationInsightsKeySecretName": {
+      "type": "string",
+      "defaultValue": "AppInsightsInstrumentationKey",
+      "metadata": {
+        "description": "The name of the key vault secret where the instrumentation key will be stored."
+      }
+    },
+    "applicationInsightsConnectionStringSecretName": {
+      "type": "string",
+      "defaultValue": "AppInsightsConnectionString",
+      "metadata": {
+        "description": "The name of the key vault secret where the connection string will be stored."
       }
     },
     "kind": {
@@ -293,10 +307,107 @@
             "value": "[parameters('keyVaultName')]"
           },
           "secretName": {
-            "value": "AppInsightsInstrumentationKey"
+            "value": "[parameters('applicationInsightsKeySecretName')]"
           },
           "contentValue": {
             "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appInsightsWithConfigPublish'), '2020-10-01').outputs.appInsightsWorkspaceResource.value.properties.InstrumentationKey]"
+          },
+          "contentType": {
+            "value": "text/plain"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "16729986519206477407"
+            }
+          },
+          "parameters": {
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Enter the secret name."
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "defaultValue": "text/plain",
+              "metadata": {
+                "description": "Type of the secret"
+              }
+            },
+            "contentValue": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Value of the secret"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the vault"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, a pre-existing secret will be returned"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2021-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "value": "[parameters('contentValue')]"
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+              "metadata": {
+                "description": "The key vault URI linking to the new/updated secret"
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'appInsightsWithConfigPublish')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "appInsightsConnectionStringSecret",
+      "subscriptionId": "[parameters('keyVaultSubscriptionId')]",
+      "resourceGroup": "[parameters('keyVaultResourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "secretName": {
+            "value": "[parameters('applicationInsightsConnectionStringSecretName')]"
+          },
+          "contentValue": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appInsightsWithConfigPublish'), '2020-10-01').outputs.appInsightsWorkspaceResource.value.properties.ConnectionString]"
           },
           "contentType": {
             "value": "text/plain"
@@ -395,6 +506,20 @@
       "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appInsightsWithConfigPublish'), '2020-10-01').outputs.appInsightsWorkspaceResource.value]",
       "metadata": {
         "description": "An object representing the app insights workspace resource"
+      }
+    },
+    "appInsightsKeySecretName": {
+      "type": "string",
+      "value": "[parameters('applicationInsightsKeySecretName')]",
+      "metadata": {
+        "description": "The name of the key vault secret where the instrumentation key will be stored."
+      }
+    },
+    "appInsightsConnectionStringSecretName": {
+      "type": "string",
+      "value": "[parameters('applicationInsightsConnectionStringSecretName')]",
+      "metadata": {
+        "description": "The name of the key vault secret where the connection string will be stored."
       }
     }
   }

--- a/modules/general/app-insights-with-config-publish/version.json
+++ b/modules/general/app-insights-with-config-publish/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "1.0",
+  "version": "1.1",
   "pathFilters": [
     "./main.json",
     "./metadata.json"


### PR DESCRIPTION
- Set connection string secret in addition to instrumentation key
- Make secret names configurable
- Set secret names as outputs so we can use them to set implicit dependencies