### PR TITLE
Add `acs-email-with-config-publish` module

### DIFF
--- a/modules/general/acs-email-with-config-publish/README.md
+++ b/modules/general/acs-email-with-config-publish/README.md
@@ -10,13 +10,13 @@ The ACS key, ACS connection string, the email domain, and the send-from email ad
 
 ## Parameters
 
-| Name                       | Type     | Required | Description                                                                                           |
-| :------------------------- | :------: | :------: | :---------------------------------------------------------------------------------------------------- |
-| `communicationServiceName` | `string` | Yes      | The name of the Azure Communication Service resource.                                                 |
-| `emailServiceName`         | `string` | Yes      | The name of the Email Communication Service resource.                                                 |
-| `dataLocation`             | `string` | Yes      | The location where the communication and email service stores its data at rest.                       |
-| `senderUsername`           | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".                                  |
-| `keyVaultName`             | `string` | Yes      | The name of the key vault where the communication service key and connection string will be published |
+| Name                       | Type     | Required | Description                                                                     |
+| :------------------------- | :------: | :------: | :------------------------------------------------------------------------------ |
+| `communicationServiceName` | `string` | Yes      | The name of the Azure Communication Service resource.                           |
+| `emailServiceName`         | `string` | Yes      | The name of the Email Communication Service resource.                           |
+| `dataLocation`             | `string` | Yes      | The location where the communication and email service stores its data at rest. |
+| `senderUsername`           | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".            |
+| `keyVaultName`             | `string` | Yes      | The name of the key vault where the configuration will be published             |
 
 ## Outputs
 

--- a/modules/general/acs-email-with-config-publish/README.md
+++ b/modules/general/acs-email-with-config-publish/README.md
@@ -1,0 +1,41 @@
+# acs-email-managed-domain-with-published-config
+
+Azure Communication Email Service with managed Azure domain, with published configuration
+
+## Description
+
+This module provisions a top-level Azure Communication Service (ACS) resource and an Email Communication resource with a managed Azure domain, linking the domain to the ACS resource. A send-from email address is also configured for the domain, which defaults to `DoNotReply@<domain>`.
+
+The ACS key, ACS connection string, the email domain, and the send-from email address are published into the specified Key Vault.
+
+## Parameters
+
+| Name                       | Type     | Required | Description                                                                                           |
+| :------------------------- | :------: | :------: | :---------------------------------------------------------------------------------------------------- |
+| `communicationServiceName` | `string` | Yes      | The name of the Azure Communication Service resource.                                                 |
+| `emailServiceName`         | `string` | Yes      | The name of the Email Communication Service resource.                                                 |
+| `dataLocation`             | `string` | Yes      | The location where the communication and email service stores its data at rest.                       |
+| `senderUsername`           | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".                                  |
+| `keyVaultName`             | `string` | Yes      | The name of the key vault where the communication service key and connection string will be published |
+
+## Outputs
+
+| Name                 | Type   | Description                                               |
+| :------------------- | :----: | :-------------------------------------------------------- |
+| domain               | string | The Azure managed domain.                                 |
+| sendFromEmailAddress | string | The send-from email address for the Azure managed domain. |
+
+## Examples
+
+### Deploy ACS email service with data storage in the UK
+
+```bicep
+module acs_email 'br:<registry-fqdn>/bicep/general/acs-email:<version>' = {
+  name: 'acsEmailDeploy'
+  params: {
+    communicationServiceName: 'myacsservice'
+    emailServiceName: 'myacsemailservice'
+    dataLocation: 'UK'
+  }
+}
+```

--- a/modules/general/acs-email-with-config-publish/README.md
+++ b/modules/general/acs-email-with-config-publish/README.md
@@ -27,15 +27,16 @@ The ACS key, ACS connection string, the email domain, and the send-from email ad
 
 ## Examples
 
-### Deploy ACS email service with data storage in the UK
+### Deploy ACS email service with data storage in the UK and publish config to Key Vault
 
 ```bicep
-module acs_email 'br:<registry-fqdn>/bicep/general/acs-email:<version>' = {
+module acs_email_with_config_publish 'br:<registry-fqdn>/bicep/general/acs-email-with-config-publish:<version>' = {
   name: 'acsEmailDeploy'
   params: {
     communicationServiceName: 'myacsservice'
     emailServiceName: 'myacsemailservice'
     dataLocation: 'UK'
+    keyVaultName: 'mykeyvault'
   }
 }
 ```

--- a/modules/general/acs-email-with-config-publish/main.bicep
+++ b/modules/general/acs-email-with-config-publish/main.bicep
@@ -28,7 +28,7 @@ param dataLocation string
 @description('The username for the sender email address. Defaults to "DoNotReply".')
 param senderUsername string = 'DoNotReply'
 
-@description('The name of the key vault where the communication service key and connection string will be published')
+@description('The name of the key vault where the configuration will be published')
 param keyVaultName string
 
 module acs_email '../acs-email/main.bicep' = {

--- a/modules/general/acs-email-with-config-publish/main.bicep
+++ b/modules/general/acs-email-with-config-publish/main.bicep
@@ -1,0 +1,61 @@
+@description('The name of the Azure Communication Service resource.')
+param communicationServiceName string
+
+@description('The name of the Email Communication Service resource.')
+param emailServiceName string
+
+@description('The location where the communication and email service stores its data at rest.')
+@allowed([
+  'Africa'
+  'Asia Pacific'
+  'Australia'
+  'Brazil'
+  'Canada'
+  'Europe'
+  'France'
+  'Germany'
+  'India'
+  'Japan'
+  'Korea'
+  'Norway'
+  'Switzerland'
+  'United Arab Emirates'
+  'UK'
+  'United States'
+])
+param dataLocation string
+
+@description('The username for the sender email address. Defaults to "DoNotReply".')
+param senderUsername string = 'DoNotReply'
+
+@description('The name of the key vault where the communication service key and connection string will be published')
+param keyVaultName string
+
+module acs_email '../acs-email/main.bicep' = {
+  name: 'AcsEmailDeploy'
+  params: {
+    communicationServiceName: communicationServiceName
+    dataLocation: dataLocation
+    emailServiceName: emailServiceName
+    senderUsername: senderUsername
+  }
+}
+
+module set_secrets './set-secrets.bicep' = {
+  name: 'acsEmailSetSecretsDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    communicationServiceName: communicationServiceName
+    domain: acs_email.outputs.domain
+    sendFromEmailAddress: acs_email.outputs.sendFromEmailAddress
+  }
+  dependsOn: [
+    acs_email
+  ]
+}
+
+@description('The Azure managed domain.')
+output domain string = acs_email.outputs.domain
+
+@description('The send-from email address for the Azure managed domain.')
+output sendFromEmailAddress string = acs_email.outputs.sendFromEmailAddress

--- a/modules/general/acs-email-with-config-publish/main.bicep
+++ b/modules/general/acs-email-with-config-publish/main.bicep
@@ -49,9 +49,6 @@ module set_secrets './set-secrets.bicep' = {
     domain: acs_email.outputs.domain
     sendFromEmailAddress: acs_email.outputs.sendFromEmailAddress
   }
-  dependsOn: [
-    acs_email
-  ]
 }
 
 @description('The Azure managed domain.')

--- a/modules/general/acs-email-with-config-publish/main.json
+++ b/modules/general/acs-email-with-config-publish/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "11118280592566014093"
+      "templateHash": "15590762678673895215"
     }
   },
   "parameters": {
@@ -55,7 +55,7 @@
     "keyVaultName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the key vault where the communication service key and connection string will be published"
+        "description": "The name of the key vault where the configuration will be published"
       }
     }
   },

--- a/modules/general/acs-email-with-config-publish/main.json
+++ b/modules/general/acs-email-with-config-publish/main.json
@@ -1,0 +1,651 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.15.31.15270",
+      "templateHash": "11118280592566014093"
+    }
+  },
+  "parameters": {
+    "communicationServiceName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Communication Service resource."
+      }
+    },
+    "emailServiceName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Email Communication Service resource."
+      }
+    },
+    "dataLocation": {
+      "type": "string",
+      "allowedValues": [
+        "Africa",
+        "Asia Pacific",
+        "Australia",
+        "Brazil",
+        "Canada",
+        "Europe",
+        "France",
+        "Germany",
+        "India",
+        "Japan",
+        "Korea",
+        "Norway",
+        "Switzerland",
+        "United Arab Emirates",
+        "UK",
+        "United States"
+      ],
+      "metadata": {
+        "description": "The location where the communication and email service stores its data at rest."
+      }
+    },
+    "senderUsername": {
+      "type": "string",
+      "defaultValue": "DoNotReply",
+      "metadata": {
+        "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+      }
+    },
+    "keyVaultName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the key vault where the communication service key and connection string will be published"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "AcsEmailDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "communicationServiceName": {
+            "value": "[parameters('communicationServiceName')]"
+          },
+          "dataLocation": {
+            "value": "[parameters('dataLocation')]"
+          },
+          "emailServiceName": {
+            "value": "[parameters('emailServiceName')]"
+          },
+          "senderUsername": {
+            "value": "[parameters('senderUsername')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "12544218465128506969"
+            }
+          },
+          "parameters": {
+            "communicationServiceName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Azure Communication Service resource."
+              }
+            },
+            "emailServiceName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Email Communication Service resource."
+              }
+            },
+            "dataLocation": {
+              "type": "string",
+              "allowedValues": [
+                "Africa",
+                "Asia Pacific",
+                "Australia",
+                "Brazil",
+                "Canada",
+                "Europe",
+                "France",
+                "Germany",
+                "India",
+                "Japan",
+                "Korea",
+                "Norway",
+                "Switzerland",
+                "United Arab Emirates",
+                "UK",
+                "United States"
+              ],
+              "metadata": {
+                "description": "The location where the communication and email service stores its data at rest."
+              }
+            },
+            "senderUsername": {
+              "type": "string",
+              "defaultValue": "DoNotReply",
+              "metadata": {
+                "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[format('{0}/{1}/{2}', parameters('emailServiceName'), 'AzureManagedDomain', parameters('senderUsername'))]",
+              "properties": {
+                "username": "[parameters('senderUsername')]",
+                "displayName": "[parameters('senderUsername')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Communication/emailServices/domains",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[format('{0}/{1}', parameters('emailServiceName'), 'AzureManagedDomain')]",
+              "location": "global",
+              "properties": {
+                "domainManagement": "AzureManaged",
+                "userEngagementTracking": "Disabled"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/emailServices', parameters('emailServiceName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Communication/communicationServices",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[parameters('communicationServiceName')]",
+              "location": "global",
+              "properties": {
+                "dataLocation": "[parameters('dataLocation')]",
+                "linkedDomains": [
+                  "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Communication/emailServices",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[parameters('emailServiceName')]",
+              "location": "global",
+              "properties": {
+                "dataLocation": "[parameters('dataLocation')]"
+              }
+            }
+          ],
+          "outputs": {
+            "domain": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain]",
+              "metadata": {
+                "description": "The Azure managed domain."
+              }
+            },
+            "sendFromEmailAddress": {
+              "type": "string",
+              "value": "[format('{0}@{1}', reference(resourceId('Microsoft.Communication/emailServices/domains/senderUsernames', parameters('emailServiceName'), 'AzureManagedDomain', parameters('senderUsername')), '2023-04-01-preview').username, reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain)]",
+              "metadata": {
+                "description": "The send-from email address for the Azure managed domain."
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "acsEmailSetSecretsDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "communicationServiceName": {
+            "value": "[parameters('communicationServiceName')]"
+          },
+          "domain": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.domain.value]"
+          },
+          "sendFromEmailAddress": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.sendFromEmailAddress.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "13841039646157215711"
+            }
+          },
+          "parameters": {
+            "keyVaultName": {
+              "type": "string"
+            },
+            "communicationServiceName": {
+              "type": "string"
+            },
+            "domain": {
+              "type": "string"
+            },
+            "sendFromEmailAddress": {
+              "type": "string"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "communicationServiceKeySecretDeploy",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "secretName": {
+                    "value": "CommunicationServiceKey"
+                  },
+                  "contentValue": {
+                    "value": "[listKeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2023-04-01-preview').primaryKey]"
+                  },
+                  "contentType": {
+                    "value": "text/plain"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.15.31.15270",
+                      "templateHash": "16729986519206477407"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "securestring",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "communicationServiceConnectionStringSecretDeploy",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "secretName": {
+                    "value": "CommunicationServiceConnectionString"
+                  },
+                  "contentValue": {
+                    "value": "[listKeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2023-04-01-preview').primaryConnectionString]"
+                  },
+                  "contentType": {
+                    "value": "text/plain"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.15.31.15270",
+                      "templateHash": "16729986519206477407"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "securestring",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "emailServiceDomainSecretDeploy",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "secretName": {
+                    "value": "EmailServiceDomain"
+                  },
+                  "contentValue": {
+                    "value": "[parameters('domain')]"
+                  },
+                  "contentType": {
+                    "value": "text/plain"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.15.31.15270",
+                      "templateHash": "16729986519206477407"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "securestring",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "emailServiceSendFromEmailAddressSecretDeploy",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "secretName": {
+                    "value": "EmailServiceSendFromEmailAddress"
+                  },
+                  "contentValue": {
+                    "value": "[parameters('sendFromEmailAddress')]"
+                  },
+                  "contentType": {
+                    "value": "text/plain"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.15.31.15270",
+                      "templateHash": "16729986519206477407"
+                    }
+                  },
+                  "parameters": {
+                    "secretName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Enter the secret name."
+                      }
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "defaultValue": "text/plain",
+                      "metadata": {
+                        "description": "Type of the secret"
+                      }
+                    },
+                    "contentValue": {
+                      "type": "securestring",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Value of the secret"
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the vault"
+                      }
+                    },
+                    "useExisting": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "When true, a pre-existing secret will be returned"
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[not(parameters('useExisting'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2021-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                      "properties": {
+                        "contentType": "[parameters('contentType')]",
+                        "value": "[parameters('contentValue')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                      "metadata": {
+                        "description": "The key vault URI linking to the new/updated secret"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy')]"
+      ]
+    }
+  ],
+  "outputs": {
+    "domain": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.domain.value]",
+      "metadata": {
+        "description": "The Azure managed domain."
+      }
+    },
+    "sendFromEmailAddress": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.sendFromEmailAddress.value]",
+      "metadata": {
+        "description": "The send-from email address for the Azure managed domain."
+      }
+    }
+  }
+}

--- a/modules/general/acs-email-with-config-publish/metadata.json
+++ b/modules/general/acs-email-with-config-publish/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "acs-email-managed-domain-with-published-config",
+  "summary": "Azure Communication Email Service with managed Azure domain, with published configuration",
+  "owner": "endjin"
+}

--- a/modules/general/acs-email-with-config-publish/set-secrets.bicep
+++ b/modules/general/acs-email-with-config-publish/set-secrets.bicep
@@ -1,0 +1,48 @@
+param keyVaultName string
+param communicationServiceName string
+param domain string
+param sendFromEmailAddress string
+
+resource communication_service 'Microsoft.Communication/communicationServices@2023-04-01-preview' existing = {
+  name: communicationServiceName
+}
+
+module communication_service_key_secret '../key-vault-secret/main.bicep' = {
+  name: 'communicationServiceKeySecretDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    secretName: 'CommunicationServiceKey'
+    contentValue: communication_service.listKeys().primaryKey
+    contentType: 'text/plain'
+  }
+}
+
+module communication_service_connectionString_secret '../key-vault-secret/main.bicep' = {
+  name: 'communicationServiceConnectionStringSecretDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    secretName: 'CommunicationServiceConnectionString'
+    contentValue: communication_service.listKeys().primaryConnectionString
+    contentType: 'text/plain'
+  }
+}
+
+module email_service_domain_secret '../key-vault-secret/main.bicep' = {
+  name: 'emailServiceDomainSecretDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    secretName: 'EmailServiceDomain'
+    contentValue: domain
+    contentType: 'text/plain'
+  }
+}
+
+module email_service_send_from_email_address_secret '../key-vault-secret/main.bicep' = {
+  name: 'emailServiceSendFromEmailAddressSecretDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    secretName: 'EmailServiceSendFromEmailAddress'
+    contentValue: sendFromEmailAddress
+    contentType: 'text/plain'
+  }
+}

--- a/modules/general/acs-email-with-config-publish/set-secrets.json
+++ b/modules/general/acs-email-with-config-publish/set-secrets.json
@@ -1,0 +1,395 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.15.31.15270",
+      "templateHash": "13841039646157215711"
+    }
+  },
+  "parameters": {
+    "keyVaultName": {
+      "type": "string"
+    },
+    "communicationServiceName": {
+      "type": "string"
+    },
+    "domain": {
+      "type": "string"
+    },
+    "sendFromEmailAddress": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "communicationServiceKeySecretDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "secretName": {
+            "value": "CommunicationServiceKey"
+          },
+          "contentValue": {
+            "value": "[listKeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2023-04-01-preview').primaryKey]"
+          },
+          "contentType": {
+            "value": "text/plain"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "16729986519206477407"
+            }
+          },
+          "parameters": {
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Enter the secret name."
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "defaultValue": "text/plain",
+              "metadata": {
+                "description": "Type of the secret"
+              }
+            },
+            "contentValue": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Value of the secret"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the vault"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, a pre-existing secret will be returned"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2021-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "value": "[parameters('contentValue')]"
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+              "metadata": {
+                "description": "The key vault URI linking to the new/updated secret"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "communicationServiceConnectionStringSecretDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "secretName": {
+            "value": "CommunicationServiceConnectionString"
+          },
+          "contentValue": {
+            "value": "[listKeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2023-04-01-preview').primaryConnectionString]"
+          },
+          "contentType": {
+            "value": "text/plain"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "16729986519206477407"
+            }
+          },
+          "parameters": {
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Enter the secret name."
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "defaultValue": "text/plain",
+              "metadata": {
+                "description": "Type of the secret"
+              }
+            },
+            "contentValue": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Value of the secret"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the vault"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, a pre-existing secret will be returned"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2021-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "value": "[parameters('contentValue')]"
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+              "metadata": {
+                "description": "The key vault URI linking to the new/updated secret"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "emailServiceDomainSecretDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "secretName": {
+            "value": "EmailServiceDomain"
+          },
+          "contentValue": {
+            "value": "[parameters('domain')]"
+          },
+          "contentType": {
+            "value": "text/plain"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "16729986519206477407"
+            }
+          },
+          "parameters": {
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Enter the secret name."
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "defaultValue": "text/plain",
+              "metadata": {
+                "description": "Type of the secret"
+              }
+            },
+            "contentValue": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Value of the secret"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the vault"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, a pre-existing secret will be returned"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2021-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "value": "[parameters('contentValue')]"
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+              "metadata": {
+                "description": "The key vault URI linking to the new/updated secret"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "emailServiceSendFromEmailAddressSecretDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "secretName": {
+            "value": "EmailServiceSendFromEmailAddress"
+          },
+          "contentValue": {
+            "value": "[parameters('sendFromEmailAddress')]"
+          },
+          "contentType": {
+            "value": "text/plain"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "16729986519206477407"
+            }
+          },
+          "parameters": {
+            "secretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Enter the secret name."
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "defaultValue": "text/plain",
+              "metadata": {
+                "description": "Type of the secret"
+              }
+            },
+            "contentValue": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Value of the secret"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the vault"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, a pre-existing secret will be returned"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2021-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "value": "[parameters('contentValue')]"
+              }
+            }
+          ],
+          "outputs": {
+            "secretUriWithVersion": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+              "metadata": {
+                "description": "The key vault URI linking to the new/updated secret"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/modules/general/acs-email-with-config-publish/test/main.test.bicep
+++ b/modules/general/acs-email-with-config-publish/test/main.test.bicep
@@ -1,0 +1,26 @@
+param suffix string = uniqueString(resourceGroup().id)
+param location string = resourceGroup().location
+
+resource key_vault 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
+  name: 'kv${suffix}'
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenant().tenantId
+    accessPolicies: []
+  }
+}
+
+module acs_email_with_config_publish '../main.bicep' = {
+  name: 'acsEmailWithConfigPublishDeploy'
+  params: {
+    communicationServiceName: 'acs-${suffix}'
+    emailServiceName: 'acs-email-${suffix}'
+    dataLocation: 'Switzerland'
+    senderUsername: 'FooBar'
+    keyVaultName: key_vault.name
+  }
+}

--- a/modules/general/acs-email-with-config-publish/test/main.test.json
+++ b/modules/general/acs-email-with-config-publish/test/main.test.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.15.31.15270",
+      "templateHash": "2492726338633339388"
+    }
+  },
+  "parameters": {
+    "prefix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "acsEmailDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "communicationServiceName": {
+            "value": "[format('{0}-acs', parameters('prefix'))]"
+          },
+          "emailServiceName": {
+            "value": "[format('{0}-acs-email', parameters('prefix'))]"
+          },
+          "dataLocation": {
+            "value": "Switzerland"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "16261129840782263991"
+            }
+          },
+          "parameters": {
+            "communicationServiceName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Azure Communication Service resource."
+              }
+            },
+            "emailServiceName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Email Communication Service resource."
+              }
+            },
+            "dataLocation": {
+              "type": "string",
+              "allowedValues": [
+                "Africa",
+                "Asia Pacific",
+                "Australia",
+                "Brazil",
+                "Canada",
+                "Europe",
+                "France",
+                "Germany",
+                "India",
+                "Japan",
+                "Korea",
+                "Norway",
+                "Switzerland",
+                "United Arab Emirates",
+                "UK",
+                "United States"
+              ],
+              "metadata": {
+                "description": "The location where the communication and email service stores its data at rest."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[format('{0}/{1}/{2}', parameters('emailServiceName'), 'AzureManagedDomain', 'DoNotReply')]",
+              "properties": {
+                "username": "DoNotReply",
+                "displayName": "DoNotReply"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Communication/emailServices/domains",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[format('{0}/{1}', parameters('emailServiceName'), 'AzureManagedDomain')]",
+              "location": "global",
+              "properties": {
+                "domainManagement": "AzureManaged",
+                "userEngagementTracking": "Disabled"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/emailServices', parameters('emailServiceName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Communication/communicationServices",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[parameters('communicationServiceName')]",
+              "location": "global",
+              "properties": {
+                "dataLocation": "[parameters('dataLocation')]",
+                "linkedDomains": [
+                  "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Communication/emailServices",
+              "apiVersion": "2023-04-01-preview",
+              "name": "[parameters('emailServiceName')]",
+              "location": "global",
+              "properties": {
+                "dataLocation": "[parameters('dataLocation')]"
+              }
+            }
+          ],
+          "outputs": {
+            "domain": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain]",
+              "metadata": {
+                "description": "The Azure managed domain."
+              }
+            },
+            "doNotReplyEmailAddress": {
+              "type": "string",
+              "value": "[format('{0}@{1}', reference(resourceId('Microsoft.Communication/emailServices/domains/senderUsernames', parameters('emailServiceName'), 'AzureManagedDomain', 'DoNotReply'), '2023-04-01-preview').username, reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain)]",
+              "metadata": {
+                "description": "The \"DoNotReply\" email address for the Azure managed domain."
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/modules/general/acs-email-with-config-publish/test/main.test.json
+++ b/modules/general/acs-email-with-config-publish/test/main.test.json
@@ -5,20 +5,38 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "2492726338633339388"
+      "templateHash": "9530892832683290607"
     }
   },
   "parameters": {
-    "prefix": {
+    "suffix": {
       "type": "string",
       "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
     }
   },
   "resources": [
     {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('kv{0}', parameters('suffix'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "tenantId": "[tenant().tenantId]",
+        "accessPolicies": []
+      }
+    },
+    {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
-      "name": "acsEmailDeploy",
+      "name": "acsEmailWithConfigPublishDeploy",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -26,13 +44,19 @@
         "mode": "Incremental",
         "parameters": {
           "communicationServiceName": {
-            "value": "[format('{0}-acs', parameters('prefix'))]"
+            "value": "[format('acs-{0}', parameters('suffix'))]"
           },
           "emailServiceName": {
-            "value": "[format('{0}-acs-email', parameters('prefix'))]"
+            "value": "[format('acs-email-{0}', parameters('suffix'))]"
           },
           "dataLocation": {
             "value": "Switzerland"
+          },
+          "senderUsername": {
+            "value": "FooBar"
+          },
+          "keyVaultName": {
+            "value": "[format('kv{0}', parameters('suffix'))]"
           }
         },
         "template": {
@@ -42,7 +66,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.15.31.15270",
-              "templateHash": "16261129840782263991"
+              "templateHash": "11118280592566014093"
             }
           },
           "parameters": {
@@ -81,77 +105,615 @@
               "metadata": {
                 "description": "The location where the communication and email service stores its data at rest."
               }
+            },
+            "senderUsername": {
+              "type": "string",
+              "defaultValue": "DoNotReply",
+              "metadata": {
+                "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the key vault where the communication service key and connection string will be published"
+              }
             }
           },
           "resources": [
             {
-              "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
-              "apiVersion": "2023-04-01-preview",
-              "name": "[format('{0}/{1}/{2}', parameters('emailServiceName'), 'AzureManagedDomain', 'DoNotReply')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "AcsEmailDeploy",
               "properties": {
-                "username": "DoNotReply",
-                "displayName": "DoNotReply"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
-              ]
-            },
-            {
-              "type": "Microsoft.Communication/emailServices/domains",
-              "apiVersion": "2023-04-01-preview",
-              "name": "[format('{0}/{1}', parameters('emailServiceName'), 'AzureManagedDomain')]",
-              "location": "global",
-              "properties": {
-                "domainManagement": "AzureManaged",
-                "userEngagementTracking": "Disabled"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Communication/emailServices', parameters('emailServiceName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Communication/communicationServices",
-              "apiVersion": "2023-04-01-preview",
-              "name": "[parameters('communicationServiceName')]",
-              "location": "global",
-              "properties": {
-                "dataLocation": "[parameters('dataLocation')]",
-                "linkedDomains": [
-                  "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
-                ]
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
-              ]
-            },
-            {
-              "type": "Microsoft.Communication/emailServices",
-              "apiVersion": "2023-04-01-preview",
-              "name": "[parameters('emailServiceName')]",
-              "location": "global",
-              "properties": {
-                "dataLocation": "[parameters('dataLocation')]"
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "communicationServiceName": {
+                    "value": "[parameters('communicationServiceName')]"
+                  },
+                  "dataLocation": {
+                    "value": "[parameters('dataLocation')]"
+                  },
+                  "emailServiceName": {
+                    "value": "[parameters('emailServiceName')]"
+                  },
+                  "senderUsername": {
+                    "value": "[parameters('senderUsername')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.15.31.15270",
+                      "templateHash": "12544218465128506969"
+                    }
+                  },
+                  "parameters": {
+                    "communicationServiceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Azure Communication Service resource."
+                      }
+                    },
+                    "emailServiceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Email Communication Service resource."
+                      }
+                    },
+                    "dataLocation": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Africa",
+                        "Asia Pacific",
+                        "Australia",
+                        "Brazil",
+                        "Canada",
+                        "Europe",
+                        "France",
+                        "Germany",
+                        "India",
+                        "Japan",
+                        "Korea",
+                        "Norway",
+                        "Switzerland",
+                        "United Arab Emirates",
+                        "UK",
+                        "United States"
+                      ],
+                      "metadata": {
+                        "description": "The location where the communication and email service stores its data at rest."
+                      }
+                    },
+                    "senderUsername": {
+                      "type": "string",
+                      "defaultValue": "DoNotReply",
+                      "metadata": {
+                        "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
+                      "apiVersion": "2023-04-01-preview",
+                      "name": "[format('{0}/{1}/{2}', parameters('emailServiceName'), 'AzureManagedDomain', parameters('senderUsername'))]",
+                      "properties": {
+                        "username": "[parameters('senderUsername')]",
+                        "displayName": "[parameters('senderUsername')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Communication/emailServices/domains",
+                      "apiVersion": "2023-04-01-preview",
+                      "name": "[format('{0}/{1}', parameters('emailServiceName'), 'AzureManagedDomain')]",
+                      "location": "global",
+                      "properties": {
+                        "domainManagement": "AzureManaged",
+                        "userEngagementTracking": "Disabled"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Communication/emailServices', parameters('emailServiceName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Communication/communicationServices",
+                      "apiVersion": "2023-04-01-preview",
+                      "name": "[parameters('communicationServiceName')]",
+                      "location": "global",
+                      "properties": {
+                        "dataLocation": "[parameters('dataLocation')]",
+                        "linkedDomains": [
+                          "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Communication/emailServices",
+                      "apiVersion": "2023-04-01-preview",
+                      "name": "[parameters('emailServiceName')]",
+                      "location": "global",
+                      "properties": {
+                        "dataLocation": "[parameters('dataLocation')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "domain": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain]",
+                      "metadata": {
+                        "description": "The Azure managed domain."
+                      }
+                    },
+                    "sendFromEmailAddress": {
+                      "type": "string",
+                      "value": "[format('{0}@{1}', reference(resourceId('Microsoft.Communication/emailServices/domains/senderUsernames', parameters('emailServiceName'), 'AzureManagedDomain', parameters('senderUsername')), '2023-04-01-preview').username, reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain)]",
+                      "metadata": {
+                        "description": "The send-from email address for the Azure managed domain."
+                      }
+                    }
+                  }
+                }
               }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "acsEmailSetSecretsDeploy",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "communicationServiceName": {
+                    "value": "[parameters('communicationServiceName')]"
+                  },
+                  "domain": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.domain.value]"
+                  },
+                  "sendFromEmailAddress": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.sendFromEmailAddress.value]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.15.31.15270",
+                      "templateHash": "13841039646157215711"
+                    }
+                  },
+                  "parameters": {
+                    "keyVaultName": {
+                      "type": "string"
+                    },
+                    "communicationServiceName": {
+                      "type": "string"
+                    },
+                    "domain": {
+                      "type": "string"
+                    },
+                    "sendFromEmailAddress": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2020-10-01",
+                      "name": "communicationServiceKeySecretDeploy",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "keyVaultName": {
+                            "value": "[parameters('keyVaultName')]"
+                          },
+                          "secretName": {
+                            "value": "CommunicationServiceKey"
+                          },
+                          "contentValue": {
+                            "value": "[listKeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2023-04-01-preview').primaryKey]"
+                          },
+                          "contentType": {
+                            "value": "text/plain"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.15.31.15270",
+                              "templateHash": "16729986519206477407"
+                            }
+                          },
+                          "parameters": {
+                            "secretName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Enter the secret name."
+                              }
+                            },
+                            "contentType": {
+                              "type": "string",
+                              "defaultValue": "text/plain",
+                              "metadata": {
+                                "description": "Type of the secret"
+                              }
+                            },
+                            "contentValue": {
+                              "type": "securestring",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Value of the secret"
+                              }
+                            },
+                            "keyVaultName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Name of the vault"
+                              }
+                            },
+                            "useExisting": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "When true, a pre-existing secret will be returned"
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "condition": "[not(parameters('useExisting'))]",
+                              "type": "Microsoft.KeyVault/vaults/secrets",
+                              "apiVersion": "2021-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                              "properties": {
+                                "contentType": "[parameters('contentType')]",
+                                "value": "[parameters('contentValue')]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "secretUriWithVersion": {
+                              "type": "string",
+                              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                              "metadata": {
+                                "description": "The key vault URI linking to the new/updated secret"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2020-10-01",
+                      "name": "communicationServiceConnectionStringSecretDeploy",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "keyVaultName": {
+                            "value": "[parameters('keyVaultName')]"
+                          },
+                          "secretName": {
+                            "value": "CommunicationServiceConnectionString"
+                          },
+                          "contentValue": {
+                            "value": "[listKeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2023-04-01-preview').primaryConnectionString]"
+                          },
+                          "contentType": {
+                            "value": "text/plain"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.15.31.15270",
+                              "templateHash": "16729986519206477407"
+                            }
+                          },
+                          "parameters": {
+                            "secretName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Enter the secret name."
+                              }
+                            },
+                            "contentType": {
+                              "type": "string",
+                              "defaultValue": "text/plain",
+                              "metadata": {
+                                "description": "Type of the secret"
+                              }
+                            },
+                            "contentValue": {
+                              "type": "securestring",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Value of the secret"
+                              }
+                            },
+                            "keyVaultName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Name of the vault"
+                              }
+                            },
+                            "useExisting": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "When true, a pre-existing secret will be returned"
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "condition": "[not(parameters('useExisting'))]",
+                              "type": "Microsoft.KeyVault/vaults/secrets",
+                              "apiVersion": "2021-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                              "properties": {
+                                "contentType": "[parameters('contentType')]",
+                                "value": "[parameters('contentValue')]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "secretUriWithVersion": {
+                              "type": "string",
+                              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                              "metadata": {
+                                "description": "The key vault URI linking to the new/updated secret"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2020-10-01",
+                      "name": "emailServiceDomainSecretDeploy",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "keyVaultName": {
+                            "value": "[parameters('keyVaultName')]"
+                          },
+                          "secretName": {
+                            "value": "EmailServiceDomain"
+                          },
+                          "contentValue": {
+                            "value": "[parameters('domain')]"
+                          },
+                          "contentType": {
+                            "value": "text/plain"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.15.31.15270",
+                              "templateHash": "16729986519206477407"
+                            }
+                          },
+                          "parameters": {
+                            "secretName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Enter the secret name."
+                              }
+                            },
+                            "contentType": {
+                              "type": "string",
+                              "defaultValue": "text/plain",
+                              "metadata": {
+                                "description": "Type of the secret"
+                              }
+                            },
+                            "contentValue": {
+                              "type": "securestring",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Value of the secret"
+                              }
+                            },
+                            "keyVaultName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Name of the vault"
+                              }
+                            },
+                            "useExisting": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "When true, a pre-existing secret will be returned"
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "condition": "[not(parameters('useExisting'))]",
+                              "type": "Microsoft.KeyVault/vaults/secrets",
+                              "apiVersion": "2021-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                              "properties": {
+                                "contentType": "[parameters('contentType')]",
+                                "value": "[parameters('contentValue')]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "secretUriWithVersion": {
+                              "type": "string",
+                              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                              "metadata": {
+                                "description": "The key vault URI linking to the new/updated secret"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2020-10-01",
+                      "name": "emailServiceSendFromEmailAddressSecretDeploy",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "keyVaultName": {
+                            "value": "[parameters('keyVaultName')]"
+                          },
+                          "secretName": {
+                            "value": "EmailServiceSendFromEmailAddress"
+                          },
+                          "contentValue": {
+                            "value": "[parameters('sendFromEmailAddress')]"
+                          },
+                          "contentType": {
+                            "value": "text/plain"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.15.31.15270",
+                              "templateHash": "16729986519206477407"
+                            }
+                          },
+                          "parameters": {
+                            "secretName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Enter the secret name."
+                              }
+                            },
+                            "contentType": {
+                              "type": "string",
+                              "defaultValue": "text/plain",
+                              "metadata": {
+                                "description": "Type of the secret"
+                              }
+                            },
+                            "contentValue": {
+                              "type": "securestring",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Value of the secret"
+                              }
+                            },
+                            "keyVaultName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Name of the vault"
+                              }
+                            },
+                            "useExisting": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "When true, a pre-existing secret will be returned"
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "condition": "[not(parameters('useExisting'))]",
+                              "type": "Microsoft.KeyVault/vaults/secrets",
+                              "apiVersion": "2021-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretName'))]",
+                              "properties": {
+                                "contentType": "[parameters('contentType')]",
+                                "value": "[parameters('contentValue')]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "secretUriWithVersion": {
+                              "type": "string",
+                              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion, reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2021-06-01-preview').secretUriWithVersion)]",
+                              "metadata": {
+                                "description": "The key vault URI linking to the new/updated secret"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy')]"
+              ]
             }
           ],
           "outputs": {
             "domain": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain]",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.domain.value]",
               "metadata": {
                 "description": "The Azure managed domain."
               }
             },
-            "doNotReplyEmailAddress": {
+            "sendFromEmailAddress": {
               "type": "string",
-              "value": "[format('{0}@{1}', reference(resourceId('Microsoft.Communication/emailServices/domains/senderUsernames', parameters('emailServiceName'), 'AzureManagedDomain', 'DoNotReply'), '2023-04-01-preview').username, reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain)]",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'AcsEmailDeploy'), '2020-10-01').outputs.sendFromEmailAddress.value]",
               "metadata": {
-                "description": "The \"DoNotReply\" email address for the Azure managed domain."
+                "description": "The send-from email address for the Azure managed domain."
               }
             }
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', format('kv{0}', parameters('suffix')))]"
+      ]
     }
   ]
 }

--- a/modules/general/acs-email-with-config-publish/version.json
+++ b/modules/general/acs-email-with-config-publish/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.0",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}


### PR DESCRIPTION
Added module to provision Azure Communication Service and Email Communication. Also publishes config to Key Vault.