### PR TITLE
Fix bug in `email-action-group` module

### DIFF
--- a/modules/alerting/email-action-group/main.bicep
+++ b/modules/alerting/email-action-group/main.bicep
@@ -12,7 +12,7 @@ param notifyEmailAddresses array
 
 
 var emailReceivers = [for email in notifyEmailAddresses: {
-  name: '${shortName}-email'
+  name: email
   emailAddress: email
   useCommonAlertSchema: false
 }]


### PR DESCRIPTION
Resolves an issue with the `emailReceivers` naming convention to ensure the `name` field is unique when multiple receivers are specified.