### PR TITLE
`acs-email` - add option to enable diagnostic logs

### DIFF
--- a/modules/general/aad-serviceprincipal/test/main.test.json
+++ b/modules/general/aad-serviceprincipal/test/main.test.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.15.31.15270",
+      "templateHash": "3058735966513648654"
+    }
+  },
+  "parameters": {
+    "prefix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "variables": {
+    "keyVaultName": "[format('{0}kv', parameters('prefix'))]",
+    "keyVaultSecretName": "Test_ServicePrincipal_Credentials"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2023-02-01",
+      "name": "[variables('keyVaultName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "tenantId": "[tenant().tenantId]"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "aadSpDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "displayName": {
+            "value": "[format('{0}aadsp', parameters('prefix'))]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "managedIdentityResourceId": {
+            "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', '<subscription-id>', '<resource-group-name>'), 'Microsoft.ManagedIdentity/userAssignedIdentities', '<name>')]"
+          },
+          "keyVaultName": {
+            "value": "[variables('keyVaultName')]"
+          },
+          "keyVaultSecretName": {
+            "value": "[variables('keyVaultSecretName')]"
+          },
+          "passwordLifetimeDays": {
+            "value": 5
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "5026647349466886113"
+            }
+          },
+          "parameters": {
+            "displayName": {
+              "type": "string",
+              "metadata": {
+                "description": "The display name of the AzureAD service principal"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The key vault where the service principal credential details will be stored"
+              }
+            },
+            "keyVaultSecretName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the key vault secret that will hold where the service principal credential details"
+              }
+            },
+            "managedIdentityResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource identifier of the managed identity used for the deployment script."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "The location in which the deployment script will be ran"
+              }
+            },
+            "passwordLifetimeDays": {
+              "type": "int",
+              "metadata": {
+                "description": "Sets the expiration of any newly-created credentials"
+              }
+            },
+            "useApplicationCredential": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, the credentials will be added to the AzureAD application instead of the service principal"
+              }
+            },
+            "rotateSecret": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, the existing credentials will be rotated"
+              }
+            },
+            "credentialDisplayName": {
+              "type": "string",
+              "defaultValue": "Created by the 'aad-serviceprincipal' ARM deployment script",
+              "metadata": {
+                "description": "The display name metadata for the credential"
+              }
+            },
+            "resourceTags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "The resource tags applied to resources"
+              }
+            }
+          },
+          "variables": {
+            "name": "[format('AadServicePrincipalScript-{0}', parameters('displayName'))]",
+            "scriptPath": "deploy-aad-service-principal.ps1",
+            "scriptContent": "[CmdletBinding()]\r\n[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'CredentialDisplayName', Justification='Only holds non-sensitive metadata')]\r\nparam (\r\n    [Parameter(Mandatory=$true)]\r\n    [string] $DisplayName,\r\n\r\n    [Parameter(Mandatory = $true)]\r\n    [string] $KeyVaultName,\r\n\r\n    [Parameter(Mandatory = $true)]\r\n    [string] $KeyVaultSecretName,\r\n\r\n    [Parameter()]\r\n    [int] $PasswordLifetimeDays = 90,\r\n\r\n    [Parameter()]\r\n    [string] $CredentialDisplayName = \"Created by the 'aad-serviceprincipal' ARM deployment script\",\r\n\r\n    [Parameter()]\r\n    [bool] $UseApplicationCredential = $false,\r\n\r\n    [Parameter()]\r\n    [bool] $RotateSecret = $false,\r\n\r\n    [Parameter()]\r\n    [string] $CorvusModulePath = $null\r\n)\r\n \r\n$ErrorActionPreference = 'Stop'\r\nSet-StrictMode -Version 4.0\r\n\r\n$azCtx = Get-AzContext\r\n$azCtx | Format-List | Out-String | Write-Host\r\n\r\nif ($CorvusModulePath) {\r\n    # Supports local testing with development versions of Corvus.Deployment\r\n    Write-Verbose \"Loading Corvus.Deployment from $CorvusModulePath\"\r\n    Import-Module $CorvusModulePath -Force -Verbose:$false\r\n}\r\nelse {\r\n    # Install the Corvus.Deployment module from PSGallery\r\n    Install-Module Corvus.Deployment -Scope CurrentUser -Repository PSGallery -Force -Verbose\r\n    Import-Module Corvus.Deployment -Verbose:$false\r\n}\r\nGet-Module Corvus.Deployment | Format-Table | Out-String | Write-Host\r\nConnect-CorvusAzure -AadTenantId $azCtx.Tenant.Id -SkipAzureCli -TenantOnly\r\n\r\n$sp,$secret = Assert-CorvusAzureServicePrincipalForRbac -Name $DisplayName `\r\n                                                        -UseApplicationCredential:$UseApplicationCredential `\r\n                                                        -CredentialDisplayName $CredentialDisplayName `\r\n                                                        -PasswordLifetimeDays $PasswordLifetimeDays `\r\n                                                        -KeyVaultName $KeyVaultName `\r\n                                                        -KeyVaultSecretName $KeyVaultSecretName `\r\n                                                        -RotateSecret:$RotateSecret `\r\n                                                        -Verbose:$VerbosePreference\r\n\r\nWrite-Verbose \"Service Principal Details:`n$($sp | ConvertTo-Json)\"\r\n\r\n\r\n# Setup ARM outputs\r\n$DeploymentScriptOutputs = @{\r\n    appId = $sp.appId       # assuming Azure Graph version of Azure PowerShell\r\n    objectId = $sp.id\r\n}\r\nWrite-Verbose \"Script Outputs:`n$($DeploymentScriptOutputs | ConvertTo-Json)\"",
+            "scriptArguments": [
+              "[format('-DisplayName \\\"{0}\\\"', parameters('displayName'))]",
+              "[format('-KeyVaultName \\\"{0}\\\"', parameters('keyVaultName'))]",
+              "[format('-KeyVaultSecretName \\\"{0}\\\"', parameters('keyVaultSecretName'))]",
+              "[format('-CredentialDisplayName \\\"{0}\\\"', parameters('credentialDisplayName'))]",
+              "[format('-UseApplicationCredential ${0}', parameters('useApplicationCredential'))]",
+              "[format('-PasswordLifetimeDays {0}', parameters('passwordLifetimeDays'))]",
+              "[format('-RotateSecret ${0}', parameters('rotateSecret'))]"
+            ]
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Resources/deploymentScripts",
+              "apiVersion": "2020-10-01",
+              "name": "[variables('name')]",
+              "location": "[parameters('location')]",
+              "kind": "AzurePowerShell",
+              "properties": {
+                "azPowerShellVersion": "8.3",
+                "retentionInterval": "P1D",
+                "cleanupPreference": "Always",
+                "scriptContent": "[variables('scriptContent')]",
+                "arguments": "[join(variables('scriptArguments'), ' ')]"
+              },
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', parameters('managedIdentityResourceId'))]": {}
+                }
+              },
+              "tags": "[parameters('resourceTags')]"
+            }
+          ],
+          "outputs": {
+            "app_id": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', variables('name')), '2020-10-01').outputs.appId]",
+              "metadata": {
+                "description": "The application/client ID of the AzureAD service principal"
+              }
+            },
+            "object_id": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', variables('name')), '2020-10-01').outputs.objectId]",
+              "metadata": {
+                "description": "The object/principal ID of the AzureAD service principal"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/modules/general/acs-email-with-config-publish/README.md
+++ b/modules/general/acs-email-with-config-publish/README.md
@@ -10,15 +10,17 @@ The ACS key, ACS connection string, the email domain, and the send-from email ad
 
 ## Parameters
 
-| Name                        | Type     | Required | Description                                                                     |
-| :-------------------------- | :------: | :------: | :------------------------------------------------------------------------------ |
-| `communicationServiceName`  | `string` | Yes      | The name of the Azure Communication Service resource.                           |
-| `emailServiceName`          | `string` | Yes      | The name of the Email Communication Service resource.                           |
-| `dataLocation`              | `string` | Yes      | The location where the communication and email service stores its data at rest. |
-| `senderUsername`            | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".            |
-| `keyVaultName`              | `string` | Yes      | The name of the key vault where the configuration will be published             |
-| `keyVaultResourceGroupName` | `string` | No       | The resource group of the key vault where the configuration will be published   |
-| `keyVaultSubscriptionId`    | `string` | No       | The subscription of the key vault where the configuration will be published     |
+| Name                        | Type     | Required | Description                                                                                                                                                                  |
+| :-------------------------- | :------: | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `communicationServiceName`  | `string` | Yes      | The name of the Azure Communication Service resource.                                                                                                                        |
+| `emailServiceName`          | `string` | Yes      | The name of the Email Communication Service resource.                                                                                                                        |
+| `dataLocation`              | `string` | Yes      | The location where the communication and email service stores its data at rest.                                                                                              |
+| `senderUsername`            | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".                                                                                                         |
+| `keyVaultName`              | `string` | Yes      | The name of the key vault where the configuration will be published                                                                                                          |
+| `keyVaultResourceGroupName` | `string` | No       | The resource group of the key vault where the configuration will be published                                                                                                |
+| `keyVaultSubscriptionId`    | `string` | No       | The subscription of the key vault where the configuration will be published                                                                                                  |
+| `enableDiagnostics`         | `bool`   | No       | If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set).                                                                                   |
+| `logAnalyticsWorkspaceId`   | `string` | No       | When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs. |
 
 ## Outputs
 

--- a/modules/general/acs-email-with-config-publish/main.bicep
+++ b/modules/general/acs-email-with-config-publish/main.bicep
@@ -37,6 +37,12 @@ param keyVaultResourceGroupName string = resourceGroup().name
 @description('The subscription of the key vault where the configuration will be published')
 param keyVaultSubscriptionId string = subscription().subscriptionId
 
+@description('If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set).')
+param enableDiagnostics bool = false
+
+@description('When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs.')
+param logAnalyticsWorkspaceId string = ''
+
 module acs_email '../acs-email/main.bicep' = {
   name: 'AcsEmailDeploy'
   params: {
@@ -44,6 +50,8 @@ module acs_email '../acs-email/main.bicep' = {
     dataLocation: dataLocation
     emailServiceName: emailServiceName
     senderUsername: senderUsername
+    enableDiagnostics: enableDiagnostics
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
   }
 }
 

--- a/modules/general/acs-email-with-config-publish/main.json
+++ b/modules/general/acs-email-with-config-publish/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "15087560913511792251"
+      "templateHash": "11742709169919955004"
     }
   },
   "parameters": {
@@ -71,6 +71,20 @@
       "metadata": {
         "description": "The subscription of the key vault where the configuration will be published"
       }
+    },
+    "enableDiagnostics": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set)."
+      }
+    },
+    "logAnalyticsWorkspaceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs."
+      }
     }
   },
   "resources": [
@@ -95,6 +109,12 @@
           },
           "senderUsername": {
             "value": "[parameters('senderUsername')]"
+          },
+          "enableDiagnostics": {
+            "value": "[parameters('enableDiagnostics')]"
+          },
+          "logAnalyticsWorkspaceId": {
+            "value": "[parameters('logAnalyticsWorkspaceId')]"
           }
         },
         "template": {
@@ -104,7 +124,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.15.31.15270",
-              "templateHash": "12544218465128506969"
+              "templateHash": "9555343672426662132"
             }
           },
           "parameters": {
@@ -149,6 +169,20 @@
               "defaultValue": "DoNotReply",
               "metadata": {
                 "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+              }
+            },
+            "enableDiagnostics": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set)."
+              }
+            },
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs."
               }
             }
           },
@@ -201,6 +235,34 @@
               "properties": {
                 "dataLocation": "[parameters('dataLocation')]"
               }
+            },
+            {
+              "condition": "[parameters('enableDiagnostics')]",
+              "type": "microsoft.insights/diagnosticSettings",
+              "apiVersion": "2016-09-01",
+              "scope": "[format('Microsoft.Communication/communicationServices/{0}', parameters('communicationServiceName'))]",
+              "name": "service",
+              "location": "[parameters('dataLocation')]",
+              "properties": {
+                "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
+                "logs": [
+                  {
+                    "category": "EmailSendMailOperational",
+                    "enabled": true
+                  },
+                  {
+                    "category": "EmailStatusUpdateOperational",
+                    "enabled": true
+                  },
+                  {
+                    "category": "EmailUserEngagementOperational",
+                    "enabled": true
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]"
+              ]
             }
           ],
           "outputs": {

--- a/modules/general/acs-email/README.md
+++ b/modules/general/acs-email/README.md
@@ -8,12 +8,14 @@ This module provisions a top-level Azure Communication Service (ACS) resource an
 
 ## Parameters
 
-| Name                       | Type     | Required | Description                                                                     |
-| :------------------------- | :------: | :------: | :------------------------------------------------------------------------------ |
-| `communicationServiceName` | `string` | Yes      | The name of the Azure Communication Service resource.                           |
-| `emailServiceName`         | `string` | Yes      | The name of the Email Communication Service resource.                           |
-| `dataLocation`             | `string` | Yes      | The location where the communication and email service stores its data at rest. |
-| `senderUsername`           | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".            |
+| Name                       | Type     | Required | Description                                                                                                                                                                  |
+| :------------------------- | :------: | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `communicationServiceName` | `string` | Yes      | The name of the Azure Communication Service resource.                                                                                                                        |
+| `emailServiceName`         | `string` | Yes      | The name of the Email Communication Service resource.                                                                                                                        |
+| `dataLocation`             | `string` | Yes      | The location where the communication and email service stores its data at rest.                                                                                              |
+| `senderUsername`           | `string` | No       | The username for the sender email address. Defaults to "DoNotReply".                                                                                                         |
+| `enableDiagnostics`        | `bool`   | No       | If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set).                                                                                   |
+| `logAnalyticsWorkspaceId`  | `string` | No       | When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs. |
 
 ## Outputs
 

--- a/modules/general/acs-email/main.bicep
+++ b/modules/general/acs-email/main.bicep
@@ -28,6 +28,12 @@ param dataLocation string
 @description('The username for the sender email address. Defaults to "DoNotReply".')
 param senderUsername string = 'DoNotReply'
 
+@description('If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set).')
+param enableDiagnostics bool = false
+
+@description('When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs.')
+param logAnalyticsWorkspaceId string = ''
+
 resource communication_service 'Microsoft.Communication/communicationServices@2023-04-01-preview' = {
   name: communicationServiceName
   location: 'global'
@@ -61,6 +67,29 @@ resource email_service 'Microsoft.Communication/emailServices@2023-04-01-preview
         displayName: senderUsername
       }
     }
+  }
+}
+
+resource acs_diagnostic_settings 'microsoft.insights/diagnosticSettings@2016-09-01' = if (enableDiagnostics) {
+  name: 'service'
+  scope: communication_service
+  location: dataLocation
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        category: 'EmailSendMailOperational'
+        enabled: true
+      }
+      {
+        category: 'EmailStatusUpdateOperational'
+        enabled: true
+      }
+      {
+        category: 'EmailUserEngagementOperational'
+        enabled: true
+      }
+    ]
   }
 }
 

--- a/modules/general/acs-email/main.json
+++ b/modules/general/acs-email/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "12544218465128506969"
+      "templateHash": "9555343672426662132"
     }
   },
   "parameters": {
@@ -50,6 +50,20 @@
       "defaultValue": "DoNotReply",
       "metadata": {
         "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+      }
+    },
+    "enableDiagnostics": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set)."
+      }
+    },
+    "logAnalyticsWorkspaceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs."
       }
     }
   },
@@ -102,6 +116,34 @@
       "properties": {
         "dataLocation": "[parameters('dataLocation')]"
       }
+    },
+    {
+      "condition": "[parameters('enableDiagnostics')]",
+      "type": "microsoft.insights/diagnosticSettings",
+      "apiVersion": "2016-09-01",
+      "scope": "[format('Microsoft.Communication/communicationServices/{0}', parameters('communicationServiceName'))]",
+      "name": "service",
+      "location": "[parameters('dataLocation')]",
+      "properties": {
+        "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
+        "logs": [
+          {
+            "category": "EmailSendMailOperational",
+            "enabled": true
+          },
+          {
+            "category": "EmailStatusUpdateOperational",
+            "enabled": true
+          },
+          {
+            "category": "EmailUserEngagementOperational",
+            "enabled": true
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]"
+      ]
     }
   ],
   "outputs": {

--- a/modules/general/acs-email/test/main.test.bicep
+++ b/modules/general/acs-email/test/main.test.bicep
@@ -1,11 +1,27 @@
-param prefix string = uniqueString(resourceGroup().id)
+param suffix string = uniqueString(resourceGroup().id)
+param location string = resourceGroup().location
+
+module log_analytics '../../log-analytics/main.bicep' = {
+  name: 'logAnalyticsDeploy'
+  params: {
+    location: location
+    dailyQuotaGb: 1
+    enableLogAccessUsingOnlyResourcePermissions: false
+    name: 'la${suffix}'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    skuName: 'PerGB2018'
+  }
+}
 
 module acs_email '../main.bicep' = {
   name: 'acsEmailDeploy'
   params: {
-    communicationServiceName: '${prefix}-acs'
-    emailServiceName: '${prefix}-acs-email'
+    communicationServiceName: 'acs-${suffix}'
+    emailServiceName: 'acs-email-${suffix}'
     dataLocation: 'Switzerland'
     senderUsername: 'FooBar'
+    enableDiagnostics: true
+    logAnalyticsWorkspaceId: log_analytics.outputs.id
   }
 }

--- a/modules/general/acs-email/test/main.test.json
+++ b/modules/general/acs-email/test/main.test.json
@@ -5,16 +5,179 @@
     "_generator": {
       "name": "bicep",
       "version": "0.15.31.15270",
-      "templateHash": "2492726338633339388"
+      "templateHash": "13439668216387196768"
     }
   },
   "parameters": {
-    "prefix": {
+    "suffix": {
       "type": "string",
       "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
     }
   },
   "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "logAnalyticsDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "dailyQuotaGb": {
+            "value": 1
+          },
+          "enableLogAccessUsingOnlyResourcePermissions": {
+            "value": false
+          },
+          "name": {
+            "value": "[format('la{0}', parameters('suffix'))]"
+          },
+          "publicNetworkAccessForIngestion": {
+            "value": "Enabled"
+          },
+          "publicNetworkAccessForQuery": {
+            "value": "Enabled"
+          },
+          "skuName": {
+            "value": "PerGB2018"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.15.31.15270",
+              "templateHash": "9781072933712379631"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the log analytics workspace"
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "The location of the log analytics workspace"
+              }
+            },
+            "skuName": {
+              "type": "string",
+              "defaultValue": "Standard",
+              "metadata": {
+                "description": "The SKU of the log analytics workspace"
+              }
+            },
+            "dailyQuotaGb": {
+              "type": "int",
+              "metadata": {
+                "description": "The daily ingestion quota (in GB) of the log analytics workspace - use \"-1\" for no limit"
+              }
+            },
+            "enableLogAccessUsingOnlyResourcePermissions": {
+              "type": "bool",
+              "metadata": {
+                "description": "When true, the log analytics workspace will only be accessible by using resource permissions"
+              }
+            },
+            "publicNetworkAccessForIngestion": {
+              "type": "string",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Indicates whether the public network access for ingestion is enabled or disabled"
+              }
+            },
+            "publicNetworkAccessForQuery": {
+              "type": "string",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Indicates whether the public network access for query is enabled or disabled"
+              }
+            },
+            "tagValues": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "The tag values of the log analytics workspace"
+              }
+            },
+            "useExisting": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When true, the details of an existing log analytics workspace will be returned; When false, the log analytics workspace is created/updated"
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[not(parameters('useExisting'))]",
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2020-10-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "sku": {
+                  "name": "[parameters('skuName')]"
+                },
+                "features": {
+                  "enableLogAccessUsingOnlyResourcePermissions": "[parameters('enableLogAccessUsingOnlyResourcePermissions')]"
+                },
+                "workspaceCapping": {
+                  "dailyQuotaGb": "[parameters('dailyQuotaGb')]"
+                },
+                "publicNetworkAccessForIngestion": "[parameters('publicNetworkAccessForIngestion')]",
+                "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]"
+              },
+              "tags": "[parameters('tagValues')]"
+            }
+          ],
+          "outputs": {
+            "workspaceResource": {
+              "type": "object",
+              "value": "[if(parameters('useExisting'), reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), '2020-10-01', 'full'), reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), '2020-10-01', 'full'))]",
+              "metadata": {
+                "description": "An object representing the log analytics workspace"
+              }
+            },
+            "name": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), parameters('name'), parameters('name'))]",
+              "metadata": {
+                "description": "The workspace resource name"
+              }
+            },
+            "id": {
+              "type": "string",
+              "value": "[if(parameters('useExisting'), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')))]",
+              "metadata": {
+                "description": "The workspace resource ID"
+              }
+            }
+          }
+        }
+      }
+    },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
@@ -26,13 +189,22 @@
         "mode": "Incremental",
         "parameters": {
           "communicationServiceName": {
-            "value": "[format('{0}-acs', parameters('prefix'))]"
+            "value": "[format('acs-{0}', parameters('suffix'))]"
           },
           "emailServiceName": {
-            "value": "[format('{0}-acs-email', parameters('prefix'))]"
+            "value": "[format('acs-email-{0}', parameters('suffix'))]"
           },
           "dataLocation": {
             "value": "Switzerland"
+          },
+          "senderUsername": {
+            "value": "FooBar"
+          },
+          "enableDiagnostics": {
+            "value": true
+          },
+          "logAnalyticsWorkspaceId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalyticsDeploy'), '2020-10-01').outputs.id.value]"
           }
         },
         "template": {
@@ -42,7 +214,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.15.31.15270",
-              "templateHash": "16261129840782263991"
+              "templateHash": "9555343672426662132"
             }
           },
           "parameters": {
@@ -81,16 +253,37 @@
               "metadata": {
                 "description": "The location where the communication and email service stores its data at rest."
               }
+            },
+            "senderUsername": {
+              "type": "string",
+              "defaultValue": "DoNotReply",
+              "metadata": {
+                "description": "The username for the sender email address. Defaults to \"DoNotReply\"."
+              }
+            },
+            "enableDiagnostics": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "If true, enable diagnostics on the workspace (`logAnalyticsWorkspaceId` must also be set)."
+              }
+            },
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "When `enableDiagnostics` is true, the workspace ID (resource ID of a Log Analytics workspace) for a Log Analytics workspace to which you would like to send Diagnostic Logs."
+              }
             }
           },
           "resources": [
             {
               "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
               "apiVersion": "2023-04-01-preview",
-              "name": "[format('{0}/{1}/{2}', parameters('emailServiceName'), 'AzureManagedDomain', 'DoNotReply')]",
+              "name": "[format('{0}/{1}/{2}', parameters('emailServiceName'), 'AzureManagedDomain', parameters('senderUsername'))]",
               "properties": {
-                "username": "DoNotReply",
-                "displayName": "DoNotReply"
+                "username": "[parameters('senderUsername')]",
+                "displayName": "[parameters('senderUsername')]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain')]"
@@ -132,6 +325,34 @@
               "properties": {
                 "dataLocation": "[parameters('dataLocation')]"
               }
+            },
+            {
+              "condition": "[parameters('enableDiagnostics')]",
+              "type": "microsoft.insights/diagnosticSettings",
+              "apiVersion": "2016-09-01",
+              "scope": "[format('Microsoft.Communication/communicationServices/{0}', parameters('communicationServiceName'))]",
+              "name": "service",
+              "location": "[parameters('dataLocation')]",
+              "properties": {
+                "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
+                "logs": [
+                  {
+                    "category": "EmailSendMailOperational",
+                    "enabled": true
+                  },
+                  {
+                    "category": "EmailStatusUpdateOperational",
+                    "enabled": true
+                  },
+                  {
+                    "category": "EmailUserEngagementOperational",
+                    "enabled": true
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]"
+              ]
             }
           ],
           "outputs": {
@@ -142,16 +363,19 @@
                 "description": "The Azure managed domain."
               }
             },
-            "doNotReplyEmailAddress": {
+            "sendFromEmailAddress": {
               "type": "string",
-              "value": "[format('{0}@{1}', reference(resourceId('Microsoft.Communication/emailServices/domains/senderUsernames', parameters('emailServiceName'), 'AzureManagedDomain', 'DoNotReply'), '2023-04-01-preview').username, reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain)]",
+              "value": "[format('{0}@{1}', reference(resourceId('Microsoft.Communication/emailServices/domains/senderUsernames', parameters('emailServiceName'), 'AzureManagedDomain', parameters('senderUsername')), '2023-04-01-preview').username, reference(resourceId('Microsoft.Communication/emailServices/domains', parameters('emailServiceName'), 'AzureManagedDomain'), '2023-04-01-preview').mailFromSenderDomain)]",
               "metadata": {
-                "description": "The \"DoNotReply\" email address for the Azure managed domain."
+                "description": "The send-from email address for the Azure managed domain."
               }
             }
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'logAnalyticsDeploy')]"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Enables all email related log categories when diagnostics is enabled for the ACS instance